### PR TITLE
Injecting rules into descendant input elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "http://vee-validate.logaretm.com",
   "repository": "https://github.com/logaretm/vee-validate",
   "scripts": {
-    "test": "nyc ava --colors",
+    "test": "nyc ava --colors --serial",
     "lint": "eslint ./src",
     "build:es": "rollup -c build/rollup.esm.config.js",
     "build:main": "rollup -c build/rollup.config.js",

--- a/src/directive.js
+++ b/src/directive.js
@@ -26,7 +26,7 @@ export default (options) => ({
     const scope = isObject(value) ? (value.scope || getScope(el)) : getScope(el);
     context.$validator.updateField(
       instance.fieldName,
-      getRules(expression, value, el, child),
+      getRules(expression, value, el, child || context),
       { scope: scope || '__global__' }
     );
   },

--- a/src/directive.js
+++ b/src/directive.js
@@ -16,7 +16,7 @@ export default (options) => ({
     listener.attach();
     listenersInstances.push({ vm: vnode.context, el, instance: listener });
   },
-  update(el, { expression, value }, { context }) {
+  update(el, { expression, value }, { context, child }) {
     const { instance } = find(listenersInstances, l => l.vm === context && l.el === el);
     // make sure we don't do uneccessary work if no expression was passed
     // nor if the expression did not change.
@@ -26,7 +26,7 @@ export default (options) => ({
     const scope = isObject(value) ? (value.scope || getScope(el)) : getScope(el);
     context.$validator.updateField(
       instance.fieldName,
-      getRules(expression, value, el),
+      getRules(expression, value, el, child),
       { scope: scope || '__global__' }
     );
   },

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -174,7 +174,7 @@ export default class ListenerGenerator {
   _attachValidatorEvent() {
     const listener = this._getScopedListener(this._getSuitableListener().listener.bind(this));
     const fieldName = this._hasFieldDependency(
-        getRules(this.binding.expression, this.binding.value, this.el, this.component)
+        getRules(this.binding.expression, this.binding.value, this.el, this.component || this.vm)
       );
     if (fieldName) {
             // Wait for the validator ready triggered when vm is mounted because maybe
@@ -427,7 +427,7 @@ export default class ListenerGenerator {
     const { context, getter } = this._resolveValueGetter();
     this.vm.$validator.attach(
       this.fieldName,
-      getRules(this.binding.expression, this.binding.value, this.el, this.component), {
+      getRules(this.binding.expression, this.binding.value, this.el, this.component || this.vm), {
         // eslint-disable-next-line
         scope: () => {
           return this.scope || getScope(this.el);

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -174,7 +174,7 @@ export default class ListenerGenerator {
   _attachValidatorEvent() {
     const listener = this._getScopedListener(this._getSuitableListener().listener.bind(this));
     const fieldName = this._hasFieldDependency(
-        getRules(this.binding.expression, this.binding.value, this.el)
+        getRules(this.binding.expression, this.binding.value, this.el, this.component)
       );
     if (fieldName) {
             // Wait for the validator ready triggered when vm is mounted because maybe
@@ -427,7 +427,7 @@ export default class ListenerGenerator {
     const { context, getter } = this._resolveValueGetter();
     this.vm.$validator.attach(
       this.fieldName,
-      getRules(this.binding.expression, this.binding.value, this.el), {
+      getRules(this.binding.expression, this.binding.value, this.el, this.component), {
         // eslint-disable-next-line
         scope: () => {
           return this.scope || getScope(this.el);

--- a/src/utils.js
+++ b/src/utils.js
@@ -203,9 +203,8 @@ export const getRules = (expression, value, el, component) => {
   if (! expression) {
     if (component && component.name && component.rulesets) {
       return component.rulesets[component.name];
-    } else {
-      return getDataAttribute(el, 'rules');
     }
+    return getDataAttribute(el, 'rules');
   }
 
   if (typeof value === 'string') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -196,11 +196,16 @@ export const find = (array, predicate) => {
  * @param {String} expression The binding expression.
  * @param {Object|String} value The binding value.
  * @param {element} el The element.
+ * @param {Object} component The component.
  * @returns {String|Object}
  */
-export const getRules = (expression, value, el) => {
+export const getRules = (expression, value, el, component) => {
   if (! expression) {
-    return getDataAttribute(el, 'rules');
+    if (component && component.name && component.rulesets) {
+      return component.rulesets[component.name];
+    } else {
+      return getDataAttribute(el, 'rules');
+    }
   }
 
   if (typeof value === 'string') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -201,8 +201,8 @@ export const find = (array, predicate) => {
  */
 export const getRules = (expression, value, el, component) => {
   if (! expression) {
-    if (component && component.name && component.rulesets) {
-      return component.rulesets[component.name];
+    if (component && (el.name || component.name) && component.rulesets) {
+      return component.rulesets[el.name || component.name];
     }
     return getDataAttribute(el, 'rules');
   }

--- a/test/utils.js
+++ b/test/utils.js
@@ -84,15 +84,13 @@ test('should return valid rules data', t => {
     email: true
   });
 
-  const component = {
-    name: 'email',
-    rulesets: {
-      email: 'required|email',
-      password: 'required',
-    },
+  const rulesets = {
+    email: 'required|email',
+    password: 'required',
   };
 
-  t.deepEqual(getRules(null, null, null, component), 'required|email');
+  t.deepEqual(getRules(null, null, {}, { name: 'email', rulesets }), 'required|email');
+  t.deepEqual(getRules(null, null, { name: 'email' }, { rulesets }), 'required|email');
 });
 
 test('assigns objects', t => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -83,6 +83,16 @@ test('should return valid rules data', t => {
     required: true,
     email: true
   });
+
+  const component = {
+    name: 'email',
+    rulesets: {
+      email: 'required|email',
+      password: 'required',
+    },
+  };
+
+  t.deepEqual(getRules(null, null, null, component), 'required|email');
 });
 
 test('assigns objects', t => {


### PR DESCRIPTION
This is the implementation for #546. Tests have also been added.

UPDATED: documentation below

---
## Rules Injection
Validator injection allows a `<form>` and all of its descendant `<input>` fields to share the same instance of `$validator`. But besides `$validator` injection, Vee-Validate also supports rules injection, again via Provide/Inject API. You can make use of this feature by:

1. Define all validation rules of the form inside `rulesets`:

```html
<script>
export default {
  provide: {
    rulesets: {
      email:    'required|email',
      password: 'required',
    },
  },
  ...
};
</script>
```

2. In your template, simply equip each input field with an empty `v-validate`, and ensure that every input field has a `name` attribute that matches a key defined in the rulesets:

```html
<input v-validate name="email" v-model="formData.email" type="text" />
...
<input v-validate name="password" v-model="formData.password" type="password" />

```

An empty directive `v-validate` will trigger the framework to look up for injected rules automatically. This helps you avoid typing rule expressions for all input fields. This approach is arguably easier than [not using the directive](http://vee-validate.logaretm.com/api.html#validator-example), as you will still benefit from event listeners that directive provides automatically.

**NOTE:** In the case where you are trying to validate a wrapper component that sits on top of a raw `<input>` (e.g., something like [`<el-input>`](http://element.eleme.io/#/en-US/component/input) from Eleme), the wrapper component must:

- emit all events that trigger validations (`@input`/`@focus`/`@blur`, etc.).
- define a `name` or `data-vv-name` attribute.
- request injection for both `$validator` and `rulesets`:

```html
<script>
export default {
  inject: ['rulesets', '$validator'],
  ...
};
</script>
```