### PR TITLE
feat: errorbag new function firstNot

### DIFF
--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -204,6 +204,17 @@ export default class ErrorBag {
 
     return (error && error.msg) || null;
   }
+  /**
+     * Gets the first error message for a specific field that not match the rule.
+     * @param {String} name The name of the field.
+     * @param {String} rule The name of the rule.
+     * @param {String} scope The name of the scope (optional).
+     */
+  firstNot (name, rule = 'required', scope) {
+    const error = this.collect(name, scope, false).filter(e => e.rule !== rule)[0];
+
+    return (error && error.msg) || null;
+  }
 
   /**
    * Removes errors by matching against the id.

--- a/tests/errorBag.js
+++ b/tests/errorBag.js
@@ -179,6 +179,20 @@ test('fetches the first error message for a specific field', () => {
   expect(errors.first('scope2.email:rule2')).toBe('mah');
 });
 
+test('fetches the first error message for a specific field that not match the rule', () => {
+  const errors = new ErrorBag();
+  errors.add('email', 'The email is required', 'required');
+
+  errors.add('email', 'The email is invalid', 'rule1');
+  errors.add('email', 'The email is shorter than 3 chars.', 'rule1');
+
+  errors.add('email', 'This is the third rule', 'rule2');
+  errors.add('email', 'This is the forth rule', 'rule2');
+
+  expect(errors.firstNot('email')).toBe('The email is invalid');
+  expect(errors.firstNot('email', 'rule1')).toBe('The email is required');
+});
+
 test('fetches the first error rule for a specific field', () => {
   const errors = new ErrorBag();
   errors.add('email', 'The email is invalid', 'rule1');


### PR DESCRIPTION
Usually, when we build up our mobile application, we don't want to show all of the error to users. 
The error from 'required' rule is useful for validating a form but also disturbing users, you know they can truly see which field is required from their little mobile phone. Only users type wrong characters we want to notice them. 

so, why not add a new function that filters all errors that not match the rule~