### PR TITLE
Plugin API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import makeMixin from './mixin';
 import makeDirective from './directive';
 import ErrorBag from './errorBag';
 import Rules from './rules';
-import { assign, warn } from './utils';
+import { assign, warn, isCallable } from './utils';
 import defaultOptions from './config';
 import mapFields from './helpers';
 
@@ -28,8 +28,17 @@ const install = (_Vue, options) => {
   Vue.directive('validate', makeDirective(config));
 };
 
+const use = (plugin, options = {}) => {
+  if (!isCallable(plugin)) {
+    return warn('The plugin must be a callable function');
+  }
+
+  plugin({ Validator, ErrorBag, Rules }, options);
+};
+
 export default {
   install,
+  use,
   mapFields,
   Validator,
   ErrorBag,

--- a/src/plugins/date/index.js
+++ b/src/plugins/date/index.js
@@ -4,7 +4,7 @@ import date_format from './date_format'; // eslint-disable-line
 import date_between from './date_between'; // eslint-disable-line
 import messages from './messages';
 
-const installDate = ({ Validator }, moment) => {
+const installDate = ({ Validator }, { moment }) => {
   if (installDate.installed) return;
 
   Validator.extend('after', after(moment));

--- a/src/plugins/date/index.js
+++ b/src/plugins/date/index.js
@@ -4,13 +4,17 @@ import date_format from './date_format'; // eslint-disable-line
 import date_between from './date_between'; // eslint-disable-line
 import messages from './messages';
 
-export default {
-  make: (moment) => ({
-    date_format: date_format(moment),
-    after: after(moment),
-    before: before(moment),
-    date_between: date_between(moment)
-  }),
-  messages,
-  installed: false
+const installDate = ({ Validator }, moment) => {
+  if (installDate.installed) return;
+
+  Validator.extend('after', after(moment));
+  Validator.extend('before', before(moment));
+  Validator.extend('date_format', date_format(moment));
+  Validator.extend('date_between', date_between(moment));
+  Validator.updateDictionary({ en: { messages } });
+  installDate.installed = true;
 };
+
+installDate.installed = false;
+
+export default installDate;

--- a/src/validator.js
+++ b/src/validator.js
@@ -167,7 +167,7 @@ export default class Validator {
       return false;
     }
 
-    datePlugin({ Validator }, moment);
+    datePlugin({ Validator }, { moment });
 
     return true;
   }

--- a/src/validator.js
+++ b/src/validator.js
@@ -5,7 +5,7 @@ import messages from './messages';
 import { isObject, isCallable, toArray, warn, createError, assign, find } from './utils';
 import Field from './field';
 import FieldBag from './fieldBag';
-import date from './plugins/date';
+import datePlugin from './plugins/date';
 
 let LOCALE = 'en';
 let STRICT_MODE = true;
@@ -164,25 +164,10 @@ export default class Validator {
   static installDateTimeValidators (moment) {
     if (typeof moment !== 'function') {
       warn('To use the date-time validators you must provide moment reference.');
-
       return false;
     }
 
-    if (date.installed) {
-      return true;
-    }
-
-    const validators = date.make(moment);
-    Object.keys(validators).forEach(name => {
-      Validator.extend(name, validators[name]);
-    });
-
-    Validator.updateDictionary({
-      en: {
-        messages: date.messages
-      }
-    });
-    date.installed = true;
+    datePlugin({ Validator }, moment);
 
     return true;
   }
@@ -358,7 +343,7 @@ export default class Validator {
       params = params.length ? params : [true];
     }
 
-    if (date.installed && this._isADateRule(rule.name)) {
+    if (datePlugin.installed && this._isADateRule(rule.name)) {
       const dateFormat = this._getDateFormat(field.rules);
       if (rule.name !== 'date_format') {
         params.push(dateFormat);


### PR DESCRIPTION
This PR aims to create a standard API to be used with 3rd party plugins that may need to extend the functionality of the plugin.

### [use(Function plugin, options)]()
The `use` method on the top level default module which is the main way to install plugins. It accepts two arguments, the first is the plugin install function, the second is any configuration or dependencies needed to install or configure the plugin.

The install function must have a very specific signature, It should accept at least one argument and at most two arguments. The first argument is called the **installation context**.

#### Installation Context
It is just a fancy way to say it is an object that wraps most of the dependencies you need to extend vee-validate. Which are: 

- `Validator` class, which can be used to add rules.
- `ErrorBag` class, which you may need to manipulate or query the errors in your app by adding new methods or properties.
- `Rules` Object, which is useful if you want to extend upon existing rules, like checking emails then verifying them against a database.

#### Options

This is the second argument that gets passed to your plugin install function, it should be an object that can contain anything like configuration object or dependencies, which is up to the author. By default this argument is an empty object if it wasn't passed to the install function.

Here is an example of the date plugin after being reworked to conform to this API:

```js
const installDate = ({ Validator }, { moment }) => {
  if (installDate.installed) return;

  Validator.extend('after', after(moment));
  Validator.extend('before', before(moment));
  Validator.extend('date_format', date_format(moment));
  Validator.extend('date_between', date_between(moment));
  Validator.updateDictionary({ en: { messages } });
  installDate.installed = true;
};

export default installDate;
```
As you can see it only needs the Validator prototype from the installation context which is made handier by ES6 destructing. It also expects moment to be present on the options which is a dependency for this plugin. Of course it handles any attempts of re-installations gracefully which is not a requirement but it is certainly nice to have.

Small example:

```js
import VeeValidate from 'vee-validate';
import myPlugin from 'some-plugin';

// We don't need options here.
VeeValidate.use(myPlugin);
```

### Benefits

This API - although limited at the moment - may open up opportunities for behavior sharing by other developers. so if you have neat rules that you want to share, you can now share them without limitations on `npm`.

We can add a small list to track them.

