### PR TITLE
Add typing for Configuration

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -1,5 +1,21 @@
 import Vue = require("vue")
 
+export class Configuration {
+    locale?: string;
+    delay?: number;
+    errorBagName?: string;
+    dictionary?: any;
+    strict?: boolean;
+    fieldsBagName?: string;
+    classes?: any;
+    classNames?: any;
+    events?: string;
+    inject?: boolean;
+    fastExit?: boolean;
+    aria?: boolean;
+    validity?: boolean;
+}
+
 export class FieldFlags {
     untouched: boolean;
     touched: boolean;


### PR DESCRIPTION
Usage:

```
Vue.use<VeeValidate.Configuration>(VeeValidate, {
        validity: false,
        aria: false,
    })
```