### PR TITLE
Add items property to ErrorBag class

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -34,6 +34,7 @@ export class ErrorField {
 
 export class ErrorBag {
     constructor();
+    items: ErrorField[];
     add(error: ErrorField): void;
     all(scope?: string): string[];
     any(scope?: string): boolean;


### PR DESCRIPTION
I need to access `ErrorBag`'s `items` property because need to get `ErrorField`'s from it and pass to another `ErrorBag` object.