### PR TITLE
[WIP] Component Interface

### DIFF
--- a/src/core/field.js
+++ b/src/core/field.js
@@ -9,7 +9,6 @@ const DEFAULT_OPTIONS = {
   name: null,
   active: true,
   required: false,
-  hasVeeOptions: false,
   rules: {},
   vm: null,
   classes: false,
@@ -44,8 +43,8 @@ export default class Field {
     this.aria = options.aria;
     this.flags = createFlags();
     this.vm = options.vm;
-    this.hasVeeConfig = options.hasVeeConfig;
     this.component = options.component;
+    this.ctorConfig = this.component ? getPath('$options.$_veeValidate', this.component) : undefined;
     this.update(options);
     this.updated = false;
   }
@@ -99,8 +98,8 @@ export default class Field {
    * If the field rejects false as a valid value for the required rule.
    */
   get rejectsFalse () {
-    if (this.isVue && this.hasVeeConfig) {
-      return getPath('$options.$vee.rejectsFalse', this.component, false);
+    if (this.isVue && this.ctorConfig) {
+      return !!this.ctorConfig.rejectsFalse;
     }
 
     if (this.isHeadless) {

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -1,4 +1,4 @@
-import { uniqId, createFlags, assign, normalizeRules, isNullOrUndefined, setDataAttribute, toggleClass, getInputEventName, debounce, isCallable, warn, toArray } from './utils';
+import { uniqId, createFlags, assign, normalizeRules, isNullOrUndefined, setDataAttribute, toggleClass, getInputEventName, debounce, isCallable, warn, toArray, getPath } from './utils';
 import Generator from './generator';
 
 const DEFAULT_OPTIONS = {
@@ -9,6 +9,7 @@ const DEFAULT_OPTIONS = {
   name: null,
   active: true,
   required: false,
+  hasVeeOptions: false,
   rules: {},
   vm: null,
   classes: false,
@@ -43,6 +44,7 @@ export default class Field {
     this.aria = options.aria;
     this.flags = createFlags();
     this.vm = options.vm;
+    this.hasVeeConfig = options.hasVeeConfig;
     this.component = options.component;
     this.update(options);
     this.updated = false;
@@ -97,7 +99,11 @@ export default class Field {
    * If the field rejects false as a valid value for the required rule.
    */
   get rejectsFalse () {
-    if (this.isVue || this.isHeadless) {
+    if (this.isVue && this.hasVeeConfig) {
+      return getPath('$options.$vee.rejectsFalse', this.component, false);
+    }
+
+    if (this.isHeadless) {
       return false;
     }
 

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -115,16 +115,18 @@ export default class Generator {
    * @param {*} vnode
    */
   static resolveEvents (el, vnode) {
-    if (vnode.child) {
-      const config = Generator.getCtorConfig(vnode);
-      if (config && config.events) {
-        return config.events;
-      }
+    let events = getDataAttribute(el, 'validate-on');
 
-      return getDataAttribute(el, 'validate-on') || (vnode.child.$attrs && vnode.child.$attrs['data-vv-validate-on']);
+    if (!events && vnode.child && vnode.child.$attrs) {
+      events = vnode.child.$attrs['data-vv-validate-on'];
     }
 
-    return getDataAttribute(el, 'validate-on');
+    if (!events && vnode.child) {
+      const config = Generator.getCtorConfig(vnode);
+      events = config.events;
+    }
+
+    return events;
   }
 
   /**

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -167,8 +167,13 @@ export default class Generator {
      * Resolves the field name to trigger validations.
      * @return {String} The field name.
      */
-  static resolveName (el, vnode) {
+  static resolveName (el, vnode, hasVeeConfig = false) {
     if (vnode.child) {
+      if (hasVeeConfig && isCallable(vnode.child.$options.$vee.name)) {
+        const boundGetter = vnode.child.$options.$vee.name.bind(vnode.child);
+        return boundGetter();
+      }
+
       return getDataAttribute(el, 'name') || (vnode.child.$attrs && (vnode.child.$attrs['data-vv-name'] || vnode.child.$attrs['name'])) || vnode.child.name;
     }
 

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -216,6 +216,12 @@ export default class Generator {
     }
 
     if (vnode.child) {
+      const path = getDataAttribute(el, 'value-path') || (vnode.child.$attrs && vnode.child.$attrs['data-vv-value-path']);
+      if (path) {
+        return () => {
+          return getPath(path, vnode.child);
+        };
+      }
       const config = Generator.getCtorConfig(vnode);
       if (config && isCallable(config.value)) {
         const boundGetter = config.value.bind(vnode.child);
@@ -226,10 +232,6 @@ export default class Generator {
       }
 
       return () => {
-        const path = getDataAttribute(el, 'value-path') || (vnode.child.$attrs && vnode.child.$attrs['data-vv-value-path']);
-        if (path) {
-          return getPath(path, vnode.child);
-        }
         return vnode.child.value;
       };
     }

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -181,7 +181,17 @@ export default class Generator {
      * @return {String} The field name.
      */
   static resolveName (el, vnode) {
-    if (vnode.child) {
+    let name = getDataAttribute(el, 'name');
+
+    if (!name && !vnode.child) {
+      return el.name;
+    }
+
+    if (!name && vnode.child && vnode.child.$attrs) {
+      name = vnode.child.$attrs['data-vv-name'] || vnode.child.$attrs['name'];
+    }
+
+    if (!name && vnode.child) {
       const config = Generator.getCtorConfig(vnode);
       if (config && isCallable(config.name)) {
         const boundGetter = config.name.bind(vnode.child);
@@ -189,10 +199,10 @@ export default class Generator {
         return boundGetter();
       }
 
-      return getDataAttribute(el, 'name') || (vnode.child.$attrs && (vnode.child.$attrs['data-vv-name'] || vnode.child.$attrs['name'])) || vnode.child.name;
+      return vnode.child.name;
     }
 
-    return getDataAttribute(el, 'name') || el.name;
+    return name;
   }
 
   /**

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -222,6 +222,7 @@ export default class Generator {
           return getPath(path, vnode.child);
         };
       }
+
       const config = Generator.getCtorConfig(vnode);
       if (config && isCallable(config.value)) {
         const boundGetter = config.value.bind(vnode.child);

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -116,6 +116,11 @@ export default class Generator {
    */
   static resolveEvents (el, vnode) {
     if (vnode.child) {
+      const config = Generator.getCtorConfig(vnode);
+      if (config && config.events) {
+        return config.events;
+      }
+
       return getDataAttribute(el, 'validate-on') || (vnode.child.$attrs && vnode.child.$attrs['data-vv-validate-on']);
     }
 

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -60,7 +60,7 @@ export default (Vue, options = {}) => {
     }
 
     // if its a root instance, inject anyways, or if it requested a new instance.
-    if (!this.$parent || (this.$options.$_veeValidate && this.$options.$_veeValidate.validator === 'new')) {
+    if (!this.$parent || (this.$options.$_veeValidate && /new/.test(this.$options.$_veeValidate.validator))) {
       this.$validator = createValidator(this, options);
     }
 

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,4 +1,4 @@
-import { isObject, isCallable, createProxy, createFlags } from './core/utils';
+import { isObject, isCallable, createProxy, createFlags, warn } from './core/utils';
 import Validator from './core/validator';
 
 const fakeFlags = createProxy({}, {
@@ -53,8 +53,14 @@ export default (Vue, options = {}) => {
   };
 
   mixin.beforeCreate = function beforeCreate () {
+    // TODO: Deprecate
+    if (this.$options.$validates) {
+      warn('The ctor $validates option has been deprecated please set the $_veeValidate.validator option to "new" instead');
+      this.$validator = createValidator(this, options);
+    }
+
     // if its a root instance, inject anyways, or if it requested a new instance.
-    if (this.$options.$validates || !this.$parent) {
+    if (!this.$parent || (this.$options.$_veeValidate && this.$options.$_veeValidate.validator === 'new')) {
       this.$validator = createValidator(this, options);
     }
 

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -54,6 +54,7 @@ export default (Vue, options = {}) => {
 
   mixin.beforeCreate = function beforeCreate () {
     // TODO: Deprecate
+    /* istanbul ignore next */
     if (this.$options.$validates) {
       warn('The ctor $validates option has been deprecated please set the $_veeValidate.validator option to "new" instead');
       this.$validator = createValidator(this, options);

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -246,13 +246,14 @@ describe('resolves the value getters', () => {
     `;
     let el = document.querySelector('#el');
     const vnode = { context: {}, child: { someval: 'test', value: 'test2', third: 33 }, data: {} };
-    const getter = Generator.resolveGetter(el, vnode);
+    let getter = Generator.resolveGetter(el, vnode);
     expect(getter()).toBe('test');
     vnode.child.someval = 'changed';
     expect(getter()).toBe('changed');
 
     // test fallback to value property.
     el.setAttribute('data-vv-value-path', '');
+    getter = Generator.resolveGetter(el, vnode);
     expect(getter()).toBe('test2');
     vnode.child.value = 'changed';
     expect(getter()).toBe('changed');

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -131,11 +131,17 @@ describe('components can have a definition object in the ctor options', () => {
       data: () => ({
         innerValue: '102'
       }),
+      props: {
+        name: String 
+      },
       inject: ['$validator'],
       $vee: {
         rejectsFalse: true,
         value: function () {
           return this.innerValue;
+        },
+        name: function () {
+          return this.name
         }
       }
     });
@@ -148,13 +154,13 @@ describe('components can have a definition object in the ctor options', () => {
       components: { Child },
       template: `
         <div>
-          <child v-validate="'required'" data-vv-name="field"></child>
+          <child v-validate="'required'" name="field"></child>
         </div>
       `
     });
   };
 
-  test('uses the value getters in the definition', () => {
+  test('uses the value getter in the definition', () => {
     const VM = createVM();
 
     const app = new VM().$mount();
@@ -165,6 +171,14 @@ describe('components can have a definition object in the ctor options', () => {
     expect(field.value).toBe('102');
     child.innerValue = 20;
     expect(field.value).toBe(20);
+  });
+
+  test('uses the name getter in the definition', () => {
+    const VM = createVM();
+
+    const app = new VM().$mount();
+    const field = app.$validator.fields.items[0];
+    expect(field.name).toBe('field');
   });
 
   test('components can reject the false value if provided in the required rule', async () => {

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -202,4 +202,42 @@ describe('components can have a definition object in the ctor options', () => {
 
     expect(await app.$validator.validate('field')).toBe(false);
   });
+
+  test('Creates a new instance when the validator option is set to new', () => {
+    const mixin = makeMixin(Vue, { inject: false });
+    const Child = Vue.extend({
+      mixins: [mixin],
+      name: 'child',
+      template: `<div></div>`,
+      $_veeValidate: {
+        validator: 'new'
+      }
+    });
+    const OtherChild = Vue.extend({
+      mixins: [mixin],
+      name: 'other-child',
+      template: `<div></div>`,
+      inject: ['$validator'],
+      computed: {
+        somval() { return 1 ;}
+      },
+      $_veeValidate: {
+        validator: 'inherit'
+      }
+    });
+    const VM = Vue.extend({
+      mixins: [mixin],
+      components: { Child, OtherChild },
+      template: `
+        <div>
+          <child></child>
+          <other-child></other-child>
+        </div>
+      `
+    });
+  
+    const app = new VM().$mount();
+    expect(app.$validator).not.toBe(app.$children[0].$validator); // got a different instance.
+    expect(app.$validator).toBe(app.$children[1].$validator); // got the parent's
+  });
 });

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -135,7 +135,7 @@ describe('components can have a definition object in the ctor options', () => {
         name: String 
       },
       inject: ['$validator'],
-      $vee: {
+      $_veeValidate: {
         rejectsFalse: true,
         value: function () {
           return this.innerValue;

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -142,7 +142,8 @@ describe('components can have a definition object in the ctor options', () => {
         },
         name: function () {
           return this.name
-        }
+        },
+        events: 'blur'
       }
     });
 
@@ -179,6 +180,15 @@ describe('components can have a definition object in the ctor options', () => {
     const app = new VM().$mount();
     const field = app.$validator.fields.items[0];
     expect(field.name).toBe('field');
+  });
+
+  test('uses the events defined in the definition', () => {
+    const VM = createVM();
+
+    const app = new VM().$mount();
+    const field = app.$validator.fields.items[0];
+    expect(field.events).toEqual(['blur']);
+    expect(field.watchers).toHaveLength(3); // blur (flags), input (flags), blur (validate)
   });
 
   test('components can reject the false value if provided in the required rule', async () => {


### PR DESCRIPTION
### Overview

Custom components validation has been supported for a while now, but was verbose if the user used custom components as their inputs instead of native HTML5 ones. Mainly because a lot of information must be gathered about these components.

The validator gathered the information using custom `data-*` attributes like `data-vv-name` and `data-vv-value-path`. Which is repetitive if you are going to use components for your validation. Except when using `v-model` which then the plugin uses the model instead as the source of a part of the information, which is the value getter part.

A common solution people tended to navigate to, is to implement a self validating components, which means the directive is used inside the component rather than on it in its parent scope. While this works, it required extra setup.

This PR introduces a simple mechanism to provide the necessary information for a custom component to be validated, by adding an object in the components constructor options, making them available in `$options` namespace.

Here is a small use-case:

```js
const Child = Vue.extend({
  $_veeValidate: {
    rejectsFalse: true,
    value: function () {
      return this.innerValue;
    }
  },
  name: 'child',
  template: `<div></div>`,
  data: () => ({
    innerValue: 'initial'
  })
});
```

As you have noted, the `$_veeValidate` (named following the official Vue style guide) option in the ctor can define the value getter so it will be used to retrieve the up-to-date value of the component whenever the validator needs to. Also it allows components to act as `checkboxes` by rejecting the `false` value from the allowed values in the `required` rule by setting the `rejectsFalse` property.

This allows component authors to support `vee-validate` integration with the intended behaviors set from their end. For example an author might decide that their component will only be validated once the user blurs the input, or whenever the component 'needs' to be validated by using a custom event name.

### Definition

The `$_veeValidate` object could contain the following properties:

| Property Name | Type | Default Value | Description |
| -----------------|:-------------:|:-----:|:-----|
| name | `Function` | `undefined` | a function that returns the component name to be registered as in the validator, cannot be an arrow function because its context will be the component itself |
| value | `Function` | `undefined` | a function that returns the component current value, will be used by the validator when it needs to resolve the field value, like calling `validate` without passing a value |
| rejectsFalse | `Boolean` | `false` | Defines `false` as an invalid value when the component is validated against the `required` rule. |
| validator | `String` | <code>'inherit&#124;new'</code> | Determines how the component get its validator instance, 'new' means it will always instantiate its own validator instance, 'inherit' means it will be injected by its parent using Provide/Inject API, the default is it will instantiate an instance unless it requests a `$validator` injection.
| events | `String`  | '<code>input&#124;blur</code>' | Pipe separated list of event names to validate when triggered

### Introduced Breaking Changes

- The `$validates` ctor option will be deprecated in favor of the mentioned `inject` option inside the namespace `$_veeValidate`.

### Checklist

- [x] Implement `value` getter option.
- [x] Implement `rejectsFalse` option.
- [x] Implement `name` getter option.
- [x] implement `events` option.
- [x] implement `validator` option.
- [x] Finalize ctor option definition and allowed properties.
- [x] Finalize ctor option name: `$_veeValidate`. 
 
#### Issues resolved by this PR:

- closes #707