### PR TITLE
Add jsDelivr hits badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ yarn add vee-validate
 
 vee-validate is also available on these cdns:
 
-- [jsdelivr cdn](https://cdn.jsdelivr.net/npm/vee-validate@latest/dist/vee-validate.js)
+- [jsdelivr cdn](https://cdn.jsdelivr.net/npm/vee-validate@latest/dist/vee-validate.js) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/vee-validate/badge?style=rounded)](https://www.jsdelivr.com/package/npm/vee-validate)
 - [unpkg](https://unpkg.com/vee-validate)
 
 ### Getting Started


### PR DESCRIPTION
Hey, I noticed that vee-validate gets 360k hits per month on jsDelivr, so I thought you might like this badge.