### PR TITLE
[WIP] Selective Imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "date-fns": "2.0.0-alpha.7",
     "eslint": "^4.5.0",
     "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",

--- a/src/config.js
+++ b/src/config.js
@@ -40,8 +40,6 @@ export default class Config {
    * Resolves the working config from a Vue instance.
    */
   static resolve (context: Object): MapObject {
-    if (!context) return Config.current;
-
     const selfConfig = getPath('$options.$_veeValidate', context, {});
 
     return assign({}, Config.current, selfConfig);

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,8 @@
-export default {
+import { assign, getPath } from './core/utils';
+
+// @flow
+
+const defaultConfig = {
   locale: 'en',
   delay: 0,
   errorBagName: 'errors',
@@ -6,10 +10,40 @@ export default {
   strict: true,
   fieldsBagName: 'fields',
   classes: false,
-  classNames: undefined,
+  classNames: null,
   events: 'input|blur',
   inject: true,
   fastExit: true,
   aria: true,
   validity: false
+};
+
+let currentConfig = assign({}, defaultConfig);
+
+export default class Config {
+  static get default () {
+    return defaultConfig;
+  }
+
+  static get current () {
+    return currentConfig;
+  }
+
+  /**
+   * Merges the config with a new one.
+   */
+  static merge (config) {
+    currentConfig = assign({}, currentConfig, config);
+  }
+
+  /**
+   * Resolves the working config from a Vue instance.
+   */
+  static resolve (context: Object): MapObject {
+    if (!context) return Config.current;
+
+    const selfConfig = getPath('$options.$_veeValidate', context, {});
+
+    return assign({}, Config.current, selfConfig);
+  }
 };

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -1,11 +1,23 @@
-import { getScope, getDataAttribute, isObject, toArray, find, getPath, hasPath, isNullOrUndefined, isCallable } from './utils';
+import {
+  getScope,
+  getPluginConfig,
+  getDataAttribute,
+  isObject,
+  toArray,
+  find,
+  getPath,
+  hasPath,
+  isNullOrUndefined,
+  isCallable
+} from './utils';
 
 /**
  * Generates the options required to construct a field.
  */
 export default class Generator {
-  static generate (el, binding, vnode, options = {}) {
+  static generate (el, binding, vnode) {
     const model = Generator.resolveModel(binding, vnode);
+    const options = getPluginConfig(vnode);
 
     return {
       name: Generator.resolveName(el, vnode),

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -1,6 +1,6 @@
+import Config from '../config';
 import {
   getScope,
-  getPluginConfig,
   getDataAttribute,
   isObject,
   toArray,
@@ -17,7 +17,7 @@ import {
 export default class Generator {
   static generate (el, binding, vnode) {
     const model = Generator.resolveModel(binding, vnode);
-    const options = getPluginConfig(vnode);
+    const options = Config.resolve(vnode.context);
 
     return {
       name: Generator.resolveName(el, vnode),

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,5 +1,4 @@
 // @flow
-import config from '../../config';
 
 /**
  * Gets the data attribute. the name must be kebab-case.
@@ -369,16 +368,4 @@ export const getInputEventName = (el: HTMLInputElement) => {
   }
 
   return 'input';
-};
-
-/**
- * Resolves a plugin config object for the current 
- */
-export const getPluginConfig = (vnode: { context: Object }): MapObject => {
-  if (!vnode.context) return config;
-
-  const rootConfig = getPath('$root.$options.$_veeValidate', vnode.context, {});
-  const selfConfig = getPath('$options.$_veeValidate', vnode.context, {});
-
-  return assign({}, config, rootConfig, selfConfig);
 };

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,4 +1,5 @@
 // @flow
+import config from '../../config';
 
 /**
  * Gets the data attribute. the name must be kebab-case.
@@ -368,4 +369,16 @@ export const getInputEventName = (el: HTMLInputElement) => {
   }
 
   return 'input';
+};
+
+/**
+ * Resolves a plugin config object for the current 
+ */
+export const getPluginConfig = (vnode: { context: Object }): MapObject => {
+  if (!vnode.context) return config;
+
+  const rootConfig = getPath('$root.$options.$_veeValidate', vnode.context, {});
+  const selfConfig = getPath('$options.$_veeValidate', vnode.context, {});
+
+  return assign({}, config, rootConfig, selfConfig);
 };

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,6 +1,5 @@
 import Generator from './core/generator';
 import Field from './core/field';
-import config from './config';
 import { getDataAttribute, isEqual, warn, assign } from './core/utils';
 
 // @flow
@@ -16,52 +15,47 @@ const findField = (el: HTMLElement, context: ValidatingVM): ?Field => {
   return context.$validator.fields.find({ id: getDataAttribute(el, 'id') });
 };
 
-const createDirective = (options: Object) => {
-  options = assign({}, config, options);
-
-  return {
-    bind (el: HTMLElement, binding, vnode) {
-      const validator = vnode.context.$validator;
-      if (! validator) {
-        warn(`No validator instance is present on vm, did you forget to inject '$validator'?`);
-        return;
-      }
-      const fieldOptions = Generator.generate(el, binding, vnode, options);
-      validator.attach(fieldOptions);
-    },
-    inserted: (el: HTMLElement, binding, vnode) => {
-      const field = findField(el, vnode.context);
-      const scope = Generator.resolveScope(el, binding, vnode);
-
-      // skip if scope hasn't changed.
-      if (!field || scope === field.scope) return;
-
-      // only update scope.
-      field.update({ scope });
-
-      // allows the field to re-evaluated once more in the update hook.
-      field.updated = false;
-    },
-    update: (el: HTMLElement, binding, vnode) => {
-      const field = findField(el, vnode.context);
-
-      // make sure we don't do uneccessary work if no important change was done.
-      if (!field || (field.updated && isEqual(binding.value, binding.oldValue))) return;
-      const scope = Generator.resolveScope(el, binding, vnode);
-      const rules = Generator.resolveRules(el, binding);
-
-      field.update({
-        scope,
-        rules
-      });
-    },
-    unbind (el: HTMLElement, binding, { context }) {
-      const field = findField(el, context);
-      if (!field) return;
-
-      context.$validator.detach(field);
+export default {
+  bind (el: HTMLElement, binding, vnode) {
+    const validator = vnode.context.$validator;
+    if (! validator) {
+      warn(`No validator instance is present on vm, did you forget to inject '$validator'?`);
+      return;
     }
-  };
-};
 
-export default createDirective;
+    const fieldOptions = Generator.generate(el, binding, vnode);
+    validator.attach(fieldOptions);
+  },
+  inserted: (el: HTMLElement, binding, vnode) => {
+    const field = findField(el, vnode.context);
+    const scope = Generator.resolveScope(el, binding, vnode);
+
+    // skip if scope hasn't changed.
+    if (!field || scope === field.scope) return;
+
+    // only update scope.
+    field.update({ scope });
+
+    // allows the field to re-evaluated once more in the update hook.
+    field.updated = false;
+  },
+  update: (el: HTMLElement, binding, vnode) => {
+    const field = findField(el, vnode.context);
+
+    // make sure we don't do unneccasary work if no important change was done.
+    if (!field || (field.updated && isEqual(binding.value, binding.oldValue))) return;
+    const scope = Generator.resolveScope(el, binding, vnode);
+    const rules = Generator.resolveRules(el, binding);
+
+    field.update({
+      scope,
+      rules
+    });
+  },
+  unbind (el: HTMLElement, binding, { context }) {
+    const field = findField(el, context);
+    if (!field) return;
+
+    context.$validator.detach(field);
+  }
+};

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,6 +1,6 @@
 import Generator from './core/generator';
 import Field from './core/field';
-import { getDataAttribute, isEqual, warn, assign } from './core/utils';
+import { getDataAttribute, isEqual, warn } from './core/utils';
 
 // @flow
 

--- a/src/install.js
+++ b/src/install.js
@@ -1,5 +1,5 @@
 import makeMixin from './mixin';
-import makeDirective from './directive';
+import directive from './directive';
 import defaultOptions from './config';
 import Validator from './core/validator';
 import { warn, assign } from './core/utils';
@@ -29,7 +29,7 @@ function install (_Vue, options = {}) {
   }
 
   Vue.mixin(makeMixin(Vue, config));
-  Vue.directive('validate', makeDirective(config));
+  Vue.directive('validate', directive);
 };
 
 export default install;

--- a/src/install.js
+++ b/src/install.js
@@ -1,8 +1,8 @@
-import makeMixin from './mixin';
+import mixin from './mixin';
 import directive from './directive';
-import defaultOptions from './config';
+import Config from './config';
 import Validator from './core/validator';
-import { warn, assign } from './core/utils';
+import { warn } from './core/utils';
 
 let Vue;
 
@@ -13,9 +13,9 @@ function install (_Vue, options = {}) {
   }
 
   Vue = _Vue;
-  const config = assign({}, defaultOptions, options);
-  if (config.dictionary) {
-    Validator.updateDictionary(config.dictionary);
+  Config.merge(options);
+  if (Config.current.dictionary) {
+    Validator.updateDictionary(Config.current.dictionary);
   }
 
   if (options) {
@@ -24,11 +24,11 @@ function install (_Vue, options = {}) {
     }
 
     if (options.strict) {
-      Validator.setStrictMode(config.strict);
+      Validator.setStrictMode(Config.current.strict);
     }
   }
 
-  Vue.mixin(makeMixin(Vue, config));
+  Vue.mixin(mixin);
   Vue.directive('validate', directive);
 };
 

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,5 +1,12 @@
-import { isObject, isCallable, createProxy, createFlags, warn, getPluginConfig } from './core/utils';
 import Validator from './core/validator';
+import Config from './config';
+import {
+  isObject,
+  isCallable,
+  createProxy,
+  createFlags,
+  warn
+} from './core/utils';
 
 // @flow
 
@@ -50,7 +57,12 @@ export default {
     return {};
   },
   beforeCreate () {
-    const options = getPluginConfig({ context: this });
+    // if its a root instance set the config if it exists.
+    if (!this.$parent) {
+      Config.merge(this.$options.$_veeValidate || {});
+    }
+
+    const options = Config.resolve(this);
     const Vue = this.$options._base; // the vue constructor.
     // TODO: Deprecate
     /* istanbul ignore next */

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,4 +1,4 @@
-import { isObject, isCallable, createProxy, createFlags, warn } from './core/utils';
+import { isObject, isCallable, createProxy, createFlags, warn, getPluginConfig } from './core/utils';
 import Validator from './core/validator';
 
 // @flow
@@ -39,9 +39,8 @@ const requestsValidator = (injections: Object | string[]) => {
  */
 const createValidator = (vm: any, options: Object) => new Validator(null, { vm, fastExit: options.fastExit });
 
-export default (Vue: any, options?: Object = {}) => {
-  const mixin = {};
-  mixin.provide = function providesValidator () {
+export default {
+  provide () {
     if (this.$validator) {
       return {
         $validator: this.$validator
@@ -49,9 +48,10 @@ export default (Vue: any, options?: Object = {}) => {
     }
 
     return {};
-  };
-
-  mixin.beforeCreate = function beforeCreate () {
+  },
+  beforeCreate () {
+    const options = getPluginConfig({ context: this });
+    const Vue = this.$options._base; // the vue constructor.
     // TODO: Deprecate
     /* istanbul ignore next */
     if (this.$options.$validates) {
@@ -96,14 +96,12 @@ export default (Vue: any, options?: Object = {}) => {
 
       return this.$validator.flags;
     };
-  };
+  },
 
-  mixin.beforeDestroy = function beforeDestroy () {
+  beforeDestroy () {
     // mark the validator paused to prevent delayed validation.
     if (this.$validator && this.$validator.ownerId === this._uid && isCallable(this.$validator.pause)) {
       this.$validator.pause();
     }
-  };
-
-  return mixin;
+  }
 };

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -10,6 +10,7 @@ import {
 
 // @flow
 
+/* istanbul ignore next */
 const fakeFlags = createProxy({}, {
   get (target, key) {
     // is a scope

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,48 @@
+import Config from '../src/config';
+
+test('it stores the default config', () => {
+  expect(Config.default).toEqual({
+    locale: 'en',
+    delay: 0,
+    errorBagName: 'errors',
+    dictionary: null,
+    strict: true,
+    fieldsBagName: 'fields',
+    classes: false,
+    classNames: null,
+    events: 'input|blur',
+    inject: true,
+    fastExit: true,
+    aria: true,
+    validity: false
+  });
+});
+
+test('it merges new config with the current one', () => {
+  expect(Config.current.aria).toBe(true);
+  Config.merge({ aria: false });
+  expect(Config.current.aria).toBe(false);
+});
+
+describe('resolves the working config from a vue instance', () => {
+  test('when no config is set', () => {
+    const conf = Config.resolve({
+      $options: {}
+    });
+
+    expect(conf.validity).toBe(false);
+  });
+
+  test('when config is set', () => {
+    const conf = Config.resolve({
+      $options: {
+        $_veeValidate: {
+          validity: true
+        }
+      }
+    });
+  
+    expect(conf.validity).toBe(true);
+  });
+  
+})

--- a/tests/directive.js
+++ b/tests/directive.js
@@ -1,9 +1,9 @@
 import Vue from 'vue/dist/vue';
-import makeDirective from '../src/directive';
+import directive from '../src/directive';
 
 test('warns if no validator was found during binding', () => {
   let VM = Vue.extend({
-    directives: { validate: makeDirective() },
+    directives: { validate: directive },
     template: `
       <input v-validate>
     `
@@ -28,7 +28,7 @@ test('adds the field after binding', () => {
     }
   };
   const VM = Vue.extend({
-    directives: { validate: makeDirective() },
+    directives: { validate: directive },
     beforeCreate() {
       this.$validator = $validator
     },
@@ -63,7 +63,7 @@ test('evaluates field options after update', done => {
     data: () => ({
       value: ''
     }),
-    directives: { validate: makeDirective() },
+    directives: { validate: directive },
     beforeCreate() {
       this.$validator = $validator
     },
@@ -98,7 +98,7 @@ test('expression can contain an object containing the scope', done => {
     data: () => ({
       value: ''
     }),
-    directives: { validate: makeDirective() },
+    directives: { validate: directive },
     beforeCreate() {
       this.$validator = $validator
     },
@@ -129,7 +129,7 @@ test('cleans up after unbinding', () => {
     detach: jest.fn()
   };
   const VM = Vue.extend({
-    directives: { validate: makeDirective() },
+    directives: { validate: directive },
     beforeCreate() {
       this.$validator = $validator
     },
@@ -170,7 +170,7 @@ test('revises scope after inserted', async () => {
       value: '',
       name: 'some'
     }),
-    directives: { validate: makeDirective() },
+    directives: { validate: directive },
     beforeCreate() {
       this.$validator = $validator
     },

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -350,7 +350,7 @@ test('generates field options', () => {
     model: 'email',
     vm: {},
     component: undefined,
-    classes: undefined,
+    classes: false,
     classNames: undefined,
     expression: 'required|max:3',
     rules: 'required|max:3',

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -351,7 +351,7 @@ test('generates field options', () => {
     vm: {},
     component: undefined,
     classes: false,
-    classNames: undefined,
+    classNames: null,
     expression: 'required|max:3',
     rules: 'required|max:3',
     initial: false,

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -3,6 +3,7 @@ import mixin from '../src/mixin';
 import directive from '../src/directive';
 import ErrorBag from '../src/core/errorBag';
 import FieldBag from '../src/core/fieldBag';
+import Config from '../src/config';
 import plugin from './../src/index';
 
 const Validator = plugin.Validator;

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -1,6 +1,6 @@
 import Vue from 'vue/dist/vue';
 import makeMixin from '../src/mixin';
-import makeDirective from '../src/directive';
+import directive from '../src/directive';
 import ErrorBag from '../src/core/errorBag';
 import FieldBag from '../src/core/fieldBag';
 import plugin from './../src/index';
@@ -148,9 +148,12 @@ describe('components can have a definition object in the ctor options', () => {
     });
 
     return Vue.extend({
+      $_veeValidate: {
+        inject: false
+      },
       mixins: [mixin],
       directives: {
-        validate: makeDirective({ inject: false })
+        validate: directive
       },
       components: { Child },
       template: `

--- a/tests/mixin.js
+++ b/tests/mixin.js
@@ -1,5 +1,5 @@
 import Vue from 'vue/dist/vue';
-import makeMixin from '../src/mixin';
+import mixin from '../src/mixin';
 import directive from '../src/directive';
 import ErrorBag from '../src/core/errorBag';
 import FieldBag from '../src/core/fieldBag';
@@ -8,21 +8,18 @@ import plugin from './../src/index';
 const Validator = plugin.Validator;
 
 test('injects an errorBag instance', () => {
-  const mixin = makeMixin(Vue);
   const VM = Vue.extend({ mixins: [mixin] });
   const app = new VM();
   expect(app.errors instanceof ErrorBag).toBe(true);
 });
 
 test('injects the flags collection', () => {
-  const mixin = makeMixin(Vue);
   const VM = Vue.extend({ mixins: [mixin] });
   const app = new VM();
   expect(typeof app.fields === 'object').toBe(true);
 });
 
 test('injects a validator instance', () => {
-  const mixin = makeMixin(Vue);
   const VM = Vue.extend({ mixins: [mixin] });
   const app = new VM();
   expect(app.$validator instanceof Validator).toBe(true);
@@ -30,7 +27,6 @@ test('injects a validator instance', () => {
 
 describe('provides validator instances using provide/inject API', () => {
   test('when auto inject is disabled', () => {
-    const mixin = makeMixin(Vue, { inject: false });
     const Child = Vue.extend({
       mixins: [mixin],
       name: 'child',
@@ -56,6 +52,9 @@ describe('provides validator instances using provide/inject API', () => {
       inject: []
     });
     const VM = Vue.extend({
+      $_veeValidate: {
+        inject: false
+      },
       mixins: [mixin],
       components: { Child, OtherChild, ThirdChild, FourthChild },
       template: `
@@ -74,7 +73,6 @@ describe('provides validator instances using provide/inject API', () => {
     expect(app.$children[2].$validator).toBe(undefined);
   });
   test('when auto inject is enabled', () => {
-    const mixin = makeMixin(Vue, { inject: true });
     const Child = Vue.extend({
       mixins: [mixin],
       name: 'child',
@@ -90,6 +88,9 @@ describe('provides validator instances using provide/inject API', () => {
       }
     });
     const VM = Vue.extend({
+      $_veeValidate: {
+        inject: false
+      },
       mixins: [mixin],
       components: { Child, OtherChild },
       template: `
@@ -107,7 +108,6 @@ describe('provides validator instances using provide/inject API', () => {
 });
 
 test('component pauses the validator before destroy if it owns it', () => {
-  const mixin = makeMixin(Vue);
   const VM = Vue.extend({ mixins: [mixin] });
   let app = new VM();
   const validator = app.$validator;
@@ -123,7 +123,6 @@ test('component pauses the validator before destroy if it owns it', () => {
 
 describe('components can have a definition object in the ctor options', () => {
   const createVM = () => {
-    const mixin = makeMixin(Vue, { inject: false });    
     const Child = Vue.extend({
       mixins: [mixin],
       name: 'child',
@@ -207,7 +206,6 @@ describe('components can have a definition object in the ctor options', () => {
   });
 
   test('Creates a new instance when the validator option is set to new', () => {
-    const mixin = makeMixin(Vue, { inject: false });
     const Child = Vue.extend({
       mixins: [mixin],
       name: 'child',
@@ -229,6 +227,9 @@ describe('components can have a definition object in the ctor options', () => {
       }
     });
     const VM = Vue.extend({
+      $_veeValidate: {
+        inject: false
+      },
       mixins: [mixin],
       components: { Child, OtherChild },
       template: `

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,6 +1142,12 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-flowtype@^2.39.1:
+  version "2.39.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.39.1.tgz#b5624622a0388bcd969f4351131232dcb9649cd5"
+  dependencies:
+    lodash "^4.15.0"
+
 eslint-plugin-import@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
@@ -2331,7 +2337,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
### Overview

Currently `vee-validate` is only usable by using Vue's plugin API

```js
Vue.use(VeeValidate);
```

Which is simple enough for most workflows, however some scenarios require having a rather selective installation, for example you want vee-validate to be working in some components but not others. Which could improve load time when using async components.

Another factor is the global pollution, VeeValidate currently injects a mixin and a directive in all components regardless if they are going to be using it or not, which is unnecessary.

This PR aims to add the ability to install vee-validate manually by converting the directive and mixin to standalone parts, so they can be imported and injected selectively into a component.

```js
import { directive, mixin } from 'vee-validate';

export default {
  directives: { validate: directive },
  mixins: [mixin],
  $_veeValidate: {
     // VeeValidate config here
  }
};
```

### Issues Fixed

closes #778 

Any thoughts are welcome, this PR might either get merged or rejected as this is not a **must-have** feature.