### PR TITLE
Implementation Two: Reset returns a promise

### DIFF
--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -45,13 +45,13 @@ export default class Validator {
           this.errors.clear();
           resolve();
         });
-      })
+      });
     } : () => {
       return new Promise((resolve, reject) => {
         this.fields.items.forEach(i => i.reset());
         this.errors.clear();
         resolve();
-      }); 
+      });
     };
     /* istanbul ignore next */
     this.clean = () => {

--- a/tests/validator.js
+++ b/tests/validator.js
@@ -788,6 +788,25 @@ test('resets errors on the next tick if available', () => {
   v.reset();
   expect(vm.$nextTick).toHaveBeenCalled();
   expect(v.errors.count()).toBe(0);
+});
+
+test('resets errors on the next tick if available, complete test asynchronously', (done) => {
+  // not available.
+  let v = new Validator();
+  const vm = { $nextTick: jest.fn(cb => cb()) };
+  v.attach(new Field(null, {}));
+  v.errors.add('some', 'message', 'by');
+  v.reset();
+  expect(v.errors.count()).toBe(0);
+
+  v = new Validator(null, { vm });
+  v.attach(new Field(null, {}));
+  v.errors.add('some', 'message', 'by');
+  v.reset().then(() => {
+    expect(vm.$nextTick).toHaveBeenCalled();
+    expect(v.errors.count()).toBe(0);
+    done();
+  });
 })
 
 test('it can handle mixed successes and errors from one field regardless of rules order', async () => {


### PR DESCRIPTION
In response to issue #843 

This is another possible implementation where reset returns a promise. Reject is never called since a reset never fails, so the callback seems to be a better implementation