### PR TITLE
Do not apply delay to blur event

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -53,7 +53,7 @@ const expression = {
         </tr>
         <tr>
             <td class="is-method-name">data-vv-delay</td>
-            <td>Specifies the delay amount in milliseconds for triggering the validation.</td>
+            <td>Specifies the delay amount in milliseconds for triggering the validation (input event only).</td>
         </tr>
         <tr>
             <td class="is-method-name">data-vv-name</td>
@@ -225,7 +225,7 @@ validator.validate('email', 'foo@bar'); // false
 <blockquote>
 <p>All validators share the same locale configuration. so any locale changes will update all validator instances across your app. For more information about how to overwrite messages and add new ones, please refer to the <a href="rules.html#custom-messages">custom messages</a> section.</p>
 </blockquote>
-<pre><code class="highlight-js">import { Validator } from 'vee-validate'; 
+<pre><code class="highlight-js">import { Validator } from 'vee-validate';
 
 // Also exposed on the class.
 Validator.setLocale('ar'); // Set all validator locales to 'ar'.

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -6,7 +6,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-100131478-1', 'auto');
 ga('send', 'pageview');
 </script><svg style="display: none;"><symbol id="github" viewbox="0 0 16 16"><path d="M8 0C3.58 0 0 3.582 0 8c0 3.535 2.292 6.533 5.47 7.59.4.075.547-.172.547-.385 0-.19-.007-.693-.01-1.36-2.226.483-2.695-1.073-2.695-1.073-.364-.924-.89-1.17-.89-1.17-.725-.496.056-.486.056-.486.803.056 1.225.824 1.225.824.714 1.223 1.873.87 2.33.665.072-.517.278-.87.507-1.07-1.777-.2-3.644-.888-3.644-3.953 0-.873.31-1.587.823-2.147-.09-.202-.36-1.015.07-2.117 0 0 .67-.215 2.2.82.64-.178 1.32-.266 2-.27.68.004 1.36.092 2 .27 1.52-1.035 2.19-.82 2.19-.82.43 1.102.16 1.915.08 2.117.51.56.82 1.274.82 2.147 0 3.073-1.87 3.75-3.65 3.947.28.24.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.14.46.55.38C13.71 14.53 16 11.53 16 8c0-4.418-3.582-8-8-8"></path></symbol><symbol id="i-star" viewbox="0 0 32 32"><path d="M16 2 L20 12 30 12 22 19 25 30 16 23 7 30 10 19 2 12 12 12 Z"></path></symbol><div class="columns is-mobile" id="app"><button :class="{ 'button': true, 'sidebar-button': true, 'is-open': sidebarToggle }" @click="sidebarToggle = ! sidebarToggle" type="button"><span class="icon"><i class="fa fa-bars"></i></span></button><div class="column is-2 sidebar-container" :class="{ 'column is-2 sidebar-container': true, 'is-open': sidebarToggle }" v-cloak><aside class="menu sidebar"><animated-button link="https://github.com/logaretm/vee-validate"><div class="flex-div" slot="default"><svg class="icon"><use xlink:href="#github"></use></svg>Star</div><div class="flex-div" slot="hover"><svg class="icon"><use xlink:href="#i-star"></use></svg>{{ stars }}</div></animated-button><p class="menu-label">Getting Started</p><ul class="menu-list"><li><a href="index.html#about">Introduction</a></li><li><a href="index.html#installation">Installation</a><ul><li><a href="index.html#npm">npm</a></li><li><a href="index.html#cdn">CDN</a></li></ul></li><li><a href="index.html#basic-example">Basic Example</a></li><li><a href="index.html#render-errors">Rendering Errors</a></li><li><a href="index.html#available-rules">Available Validations</a></li><li><a href="index.html#configuration">Configuration</a></li></ul><p class="menu-label">Validation Rules</p><ul class="menu-list"><li><a href="rules.html#syntax">Syntax</a></li><li><a href="rules.html#available-validations">Available Validations</a></li><li><a href="rules.html#custom-rules">Custom Validations</a></li><li><a href="rules.html#custom-messages">Custom Messages</a></li><li><a href="rules.html#custom-attributes">Custom Attributes</a></li><li><a href="rules.html#field-sepecific-messages">Field-specific Custom Messages  </a></li></ul><p class="menu-label">Localization</p><ul class="menu-list"><li><a href="localization.html#translation">Translation</a></li><li><a href="localization.html#attributes-data-as">Attributes</a><ul><li><a href="localization.html#attributes-data-as">alias</a></li><li><a href="localization.html#attributes-dictionary">dictionary</a></li></ul></li><li><a href="localization.html#localized-files">Localized Files</a></li></ul><p class="menu-label">Advanced</p><ul class="menu-list"><li><a href="advanced.html#inject">Component Injections</a></li></ul><p class="menu-label">Examples</p><ul class="menu-list"><li><a href="examples.html#debounce-example">Debounce</a></li><li><a href="examples.html#reject-example">Reject Files</a></li><li><a href="examples.html#validate-data-example">Validating Models</a></li><li><a href="examples.html#initial-value">Initial Value Validation</a></li><li><a href="examples.html#validate-form">Form Validation</a></li><li><a href="examples.html#locale-example">Localized Messages</a></li><li><a href="examples.html#scope-example">Validation Scopes</a></li><li><a href="examples.html#coupon-example">Custom Validation: Coupon</a></li><li><a href="examples.html#radio-buttons-example">Radio Buttons Validation</a></li><li><a href="examples.html#checkbox-example">Checkbox Example</a></li><li><a href="examples.html#flags-example">Validation Flags</a></li><li><a href="examples.html#selectors-example">Error Selectors</a></li><li><a href="examples.html#component-example">Component Validation</a></li><li><a href="examples.html#event-bus-example">Event Bus</a></li></ul><p class="menu-label">API</p><ul class="menu-list"><li><a href="api.html#directive">v-validate</a></li><li><a href="api.html#data-attributes">data-* Attributes</a></li><li><a href="api.html#error-bag">Error Bag</a></li><li><a href="api.html#validator">Validator</a><ul><li><a href="api.html#validator">API</a></li><li><a href="api.html#validator-example">Example</a></li></ul></li></ul></aside></div><div class="column columns is-mobile main-container" @click="sidebarToggle = false"><div class="column is-12"><section class="hero"><div class="hero-body"><div class="container has-text-centered"><img width="150" alt="VeeValidate Logo" src="https://s3.eu-central-1.amazonaws.com/logaretm/vee-validate.svg"><h1 class="title is-2">Examples </h1><h2 class="subtitle is-4">Usage and Examples</h2></div></div></section><div class="container"><div class="column content-container is-mobile"><h2><a href="#debounce-example">Delayed Validation (Debounced)</a></h2>
-<p>You can specify a delay to debounce the input event, a case scenario that you may want to wait for the user to stop typing then validate the field. This can be achieved by adding a <code>data-vv-delay</code> attribute on the field being validated, and assign it the number of milliseconds you want to wait for.</p>
+<p>You can specify a delay to debounce the input event, a case scenario that you may want to wait for the user to stop typing then validate the field. This can be achieved by adding a <code>data-vv-delay</code> attribute on the field being validated, and assign it the number of milliseconds you want to wait for. (Notice: This directive only affects the input event and will override global configuarion for the input event)</p>
 <code-example><div slot="example"><delay-example></delay-example></div><div slot="js">export default {
   name: 'delay-example'
 };
@@ -488,15 +488,15 @@ export default {
 }
 </code></pre>
 <p>The global fields flags are accessed via objects like this:</p>
-<pre><code class="highlight-js">// Is the 'name' field dirty? 
+<pre><code class="highlight-js">// Is the 'name' field dirty?
 this.fields.name.dirty;
 </code></pre>
 <p>However, for the scoped fields the <strong>FieldBag</strong> will group those fields in an property name that is prefixed by a <code>$</code> to indicate that it is a scope object:</p>
-<pre><code class="highlight-js">// Is the 'name' field dirty? 
+<pre><code class="highlight-js">// Is the 'name' field dirty?
 this.fields.$myScope.name.dirty;
 
-// Is the 'name' field clean? 
-this.fields.$myScope.name.pristine; 
+// Is the 'name' field clean?
+this.fields.$myScope.name.pristine;
 </code></pre>
 <p>Here is what it would look like:</p>
 <pre><code class="highlight-html">&lt;div class=&quot;form-input&quot;&gt;
@@ -564,10 +564,10 @@ this.$validator.flag('scoped.field', {
 </code></pre>
 <p>For custom components, in order for the flags to fully work reliably, you need to emit those events:</p>
 <p>The input event, which you probably already emit, will set the dirty and pristine flags.</p>
-<pre><code class="highlight-js">this.$emit('input', value); 
+<pre><code class="highlight-js">this.$emit('input', value);
 
 // The focus event which will set the touched and untouched flags.
-this.$emit('focus'); 
+this.$emit('focus');
 </code></pre>
 <p>Here is an example that displays those flags, intereact with the input and watch the flags change accordingly:</p>
 <code-example><div slot="example"><flags-example></flags-example></div><div slot="js">import { mapFields } from 'vee-validate';
@@ -590,7 +590,7 @@ export default {
         &lt;p class=&quot;control has-icon has-icon-right&quot;&gt;
             &lt;input name=&quot;name&quot; v-validate=&quot;'required|alpha'&quot; :class=&quot;{'input': true }&quot; type=&quot;text&quot; placeholder=&quot;Name&quot;&gt;
         &lt;/p&gt;
-        &lt;pre&gt;{{&quot;{&quot; + &quot;{ nameFlags }&quot; + &quot;}&quot;}}&lt;/pre&gt;            
+        &lt;pre&gt;{{&quot;{&quot; + &quot;{ nameFlags }&quot; + &quot;}&quot;}}&lt;/pre&gt;
     &lt;/div&gt;
 &lt;/div&gt;
 </div></code-example><h2><a href="#selectors-example">Error Selectors</a></h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@ ga('send', 'pageview');
 <pre><code class="highlight-html">  &lt;script src=&quot;path/to/vue.js&quot;&gt;&lt;/script&gt;
   &lt;script src=&quot;path/to/vee-validate.js&quot;&gt;&lt;/script&gt;
   &lt;script&gt;
-    Vue.use(VeeValidate); // good to go. 
+    Vue.use(VeeValidate); // good to go.
   &lt;/script&gt;
 </code></pre>
 <p>or you may import it using <strong>ES6</strong>:</p>
@@ -63,7 +63,7 @@ Vue.use(VeeValidate);
 <h2><a href="#available-rules">Available Rules</a></h2>
 <p>There are more than 20 rules available to validate your inputs:</p>
 <div class="columns is-multiline">
-  <div class="column is-4"> 
+  <div class="column is-4">
 <ul>
 <li>
 <p><a href="rules.html#rule-after">after</a></p>
@@ -173,12 +173,12 @@ import VeeValidate from 'vee-validate';
 
 const config = {
   errorBagName: 'errors', // change if property conflicts
-  fieldsBagName: 'fields', 
-  delay: 0, 
-  locale: 'en', 
-  dictionary: null, 
-  strict: true, 
-  classes: false, 
+  fieldsBagName: 'fields',
+  delay: 0,
+  locale: 'en',
+  dictionary: null,
+  strict: true,
+  classes: false,
   classNames: {
     touched: 'touched', // the control has been blurred
     untouched: 'untouched', // the control hasn't been blurred
@@ -211,13 +211,13 @@ Vue.use(VeeValidate, config);
         </tr>
         <tr>
             <td class="is-method-name">fieldsBagName</td>
-            <td>fields</td>            
+            <td>fields</td>
             <td>The name of the Fields (flags) object that will be injected in each of Vue's instances' data.</td>
         </tr>
         <tr>
             <td class="is-method-name">delay</td>
             <td>0</td>
-            <td>The default debounce time for all inputs (only affects validations).</td>
+            <td>The default debounce time for all inputs (only affects validations). This can optionally contain an object in the form of { event: delay, ... } where delays can be specified on a per event basis.</td>
         </tr>
         <tr>
             <td class="is-method-name">locale</td>
@@ -227,7 +227,7 @@ Vue.use(VeeValidate, config);
         <tr>
             <td class="is-method-name">dictionary</td>
             <td>null</td>
-            <td>  
+            <td>
               A dictionary to be merged with the validators dictionary. (Check the [custom messages](rules.html#custom-messages) and [localization](localization.html) sections.)
             </td>
         </tr>

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -469,11 +469,11 @@ export default class Field {
     // Add events.
     events.forEach(e => {
       if (this.isVue) {
-        this.component.$on(e, validate);
+        this.component.$on(e, (e === 'blur') ? debounce(fn, 0) : validate);
         this.watchers.push({
           tag: 'input_vue',
           unwatch: () => {
-            this.component.$off(e, validate);
+            this.component.$off(e, (e === 'blur') ? debounce(fn, 0) : validate);
           }
         });
         return;
@@ -482,11 +482,11 @@ export default class Field {
       if (~['radio', 'checkbox'].indexOf(this.el.type)) {
         const els = document.querySelectorAll(`input[name="${this.el.name}"]`);
         toArray(els).forEach(el => {
-          el.addEventListener(e, validate);
+          el.addEventListener(e, (e === 'blur') ? debounce(fn, 0) : validate);
           this.watchers.push({
             tag: 'input_native',
             unwatch: () => {
-              el.removeEventListener(e, validate);
+              el.removeEventListener(e, (e === 'blur') ? debounce(fn, 0) : validate);
             }
           });
         });
@@ -494,11 +494,11 @@ export default class Field {
         return;
       }
 
-      this.el.addEventListener(e, validate);
+      this.el.addEventListener(e, (e === 'blur') ? debounce(fn, 0) : validate);
       this.watchers.push({
         tag: 'input_native',
         unwatch: () => {
-          this.el.removeEventListener(e, validate);
+          this.el.removeEventListener(e, (e === 'blur') ? debounce(fn, 0) : validate);
         }
       });
     });

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -467,7 +467,7 @@ export default class Field {
     if (typeof this.delay !== 'object') {
       this.delay = delayObject;
     } else {
-      this.delay = Object.assign(delayObject, this.delay);
+      this.delay = assign(delayObject, this.delay);
     }
 
     // if there is a watchable model and an on input validation is requested.

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -459,7 +459,7 @@ export default class Field {
 
     // Create a delay object that includes every event we have configured
     events.forEach(e => {
-      delayObject[e] = (typeof this.delay === 'object') ? this.delay[e] : this.delay;
+      delayObject[e] = (typeof this.delay === 'object') ? 0 : this.delay;
     });
 
     // If we got an object from delay configuration we merge it, if we got

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -454,9 +454,25 @@ export default class Field {
       return e === 'input' ? inputEvent : e;
     });
 
+    // Temporary object for delays since we always want a delay object
+    let delayObject = {};
+
+    // Create a delay object that includes every event we have configured
+    events.forEach(e => {
+      delayObject[e] = (typeof this.delay === 'object') ? this.delay[e] : this.delay;
+    });
+
+    // If we got an object from delay configuration we merge it, if we got
+    // a string we just replace it with our temporary object
+    if (typeof this.delay !== 'object') {
+      this.delay = delayObject;
+    } else {
+      this.delay = Object.assign(delayObject, this.delay);
+    }
+
     // if there is a watchable model and an on input validation is requested.
     if (this.model && events.indexOf(inputEvent) !== -1) {
-      const unwatch = this.vm.$watch(this.model, (typeof this.delay === 'object') ? this.delay['input'] : this.delay);
+      const unwatch = this.vm.$watch(this.model, this.delay[inputEvent]);
       this.watchers.push({
         tag: 'input_model',
         unwatch
@@ -467,7 +483,7 @@ export default class Field {
 
     // Add events.
     events.forEach(e => {
-      let validate = debounce(fn, (typeof this.delay === 'object') ? this.delay[e] : this.delay);
+      let validate = debounce(fn, this.delay[e]);
 
       if (this.isVue) {
         this.component.$on(e, validate);

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -32,7 +32,7 @@ export default class Generator {
       getter: Generator.resolveGetter(el, vnode, model),
       events: Generator.resolveEvents(el, vnode) || options.events,
       model,
-      delay: { input: Generator.resolveDelay(el, vnode, options) },
+      delay: Object.assign(options.delay, { input: Generator.resolveDelay(el, vnode, options) }),
       rules: Generator.resolveRules(el, binding),
       initial: !!binding.modifiers.initial,
       alias: Generator.resolveAlias(el, vnode),

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -9,7 +9,7 @@ import {
   hasPath,
   isNullOrUndefined,
   isCallable,
-  assign
+  deepParseInt,
 } from './utils';
 
 /**
@@ -33,7 +33,7 @@ export default class Generator {
       getter: Generator.resolveGetter(el, vnode, model),
       events: Generator.resolveEvents(el, vnode) || options.events,
       model,
-      delay: assign(options.delay, { input: Generator.resolveDelay(el, vnode, options) }),
+      delay: Generator.resolveDelay(el, vnode, options),
       rules: Generator.resolveRules(el, binding),
       initial: !!binding.modifiers.initial,
       alias: Generator.resolveAlias(el, vnode),
@@ -108,8 +108,15 @@ export default class Generator {
    * @param {*} vnode
    * @param {Object} options
    */
-  static resolveDelay (el, vnode, options = {}) {
-    return getDataAttribute(el, 'delay') || (vnode.child && vnode.child.$attrs && vnode.child.$attrs['data-vv-delay']) || options.delay;
+  static resolveDelay (el, vnode, options) {
+    let delay = getDataAttribute(el, 'delay');
+    let globalDelay = (options && 'delay' in options) ? options.delay : 0;
+
+    if (!delay && vnode.child && vnode.child.$attrs) {
+      delay = vnode.child.$attrs['data-vv-delay'];
+    }
+
+    return (delay) ? { local: { input: parseInt(delay) }, global: deepParseInt(globalDelay) } : { global: deepParseInt(globalDelay) };
   }
 
   /**

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -32,7 +32,7 @@ export default class Generator {
       getter: Generator.resolveGetter(el, vnode, model),
       events: Generator.resolveEvents(el, vnode) || options.events,
       model,
-      delay: Generator.resolveDelay(el, vnode, options),
+      delay: { input: Generator.resolveDelay(el, vnode, options) },
       rules: Generator.resolveRules(el, binding),
       initial: !!binding.modifiers.initial,
       alias: Generator.resolveAlias(el, vnode),

--- a/src/core/generator.js
+++ b/src/core/generator.js
@@ -8,7 +8,8 @@ import {
   getPath,
   hasPath,
   isNullOrUndefined,
-  isCallable
+  isCallable,
+  assign
 } from './utils';
 
 /**
@@ -32,7 +33,7 @@ export default class Generator {
       getter: Generator.resolveGetter(el, vnode, model),
       events: Generator.resolveEvents(el, vnode) || options.events,
       model,
-      delay: Object.assign(options.delay, { input: Generator.resolveDelay(el, vnode, options) }),
+      delay: assign(options.delay, { input: Generator.resolveDelay(el, vnode, options) }),
       rules: Generator.resolveRules(el, binding),
       initial: !!binding.modifiers.initial,
       alias: Generator.resolveAlias(el, vnode),

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -378,5 +378,34 @@ export const isBuiltInComponent = (vnode): boolean => {
   const tag = vnode.componentOptions.tag;
 
   return /keep-alive|transition|transition-group/.test(tag);
-}
-;
+};
+
+export const makeEventsArray = (events: string) => {
+  return (typeof events === 'string' && events.length) ? events.split('|') : [];
+};
+
+export const makeDelayObject = (events: string[], delay: object | number) => {
+  let delayObject = {};
+
+  // We already have a valid delay object
+  if (typeof delay === 'object' && !('global' in delay) && !('local' in delay) && Object.keys(delay).length) return delay;
+
+  let globalDelay = (typeof delay === 'object' && 'global' in delay) ? delay.global : delay || 0;
+  let localDelay = (typeof delay === 'object' && 'local' in delay) ? delay.local : {};
+
+  events.forEach(e => {
+    delayObject[e] = (typeof globalDelay === 'object') ? localDelay[e] || globalDelay[e] || 0 : localDelay[e] || globalDelay;
+  });
+
+  return delayObject;
+};
+
+export const deepParseInt = (input: object | string) => {
+  if (typeof input === 'string') return parseInt(input);
+
+  for (const element in input) {
+    input[element] = parseInt(input[element]);
+  }
+
+  return input;
+};

--- a/tests/field.js
+++ b/tests/field.js
@@ -10,7 +10,7 @@ test('constructs a headless field with default values', () => {
   expect(field.rules).toEqual({});
   expect(field.events).toEqual(['input', 'blur']);
   expect(field.watchers.length).toBe(0);
-  expect(field.delay).toBe(0);
+  expect(field.delay).toEqual({'input': 0, 'blur': 0});
   expect(field.flags).toEqual({
     untouched: true,
     touched: false,

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -72,11 +72,11 @@ test('resolves delay', () => {
   `;
   const vnode = { child: { $attrs: { 'data-vv-delay': '200' } } };
   let el = document.querySelector('#el');
-  expect(Generator.resolveDelay(el, {})).toBe('100');
+  expect(Generator.resolveDelay(el, {})).toEqual(expect.objectContaining({ local: { input: 100 } }));
 
   el = { getAttribute: () => null };
-  expect(Generator.resolveDelay(el, vnode)).toBe('200');
-  expect(Generator.resolveDelay(el, {}, { delay: '300' })).toBe('300');
+  expect(Generator.resolveDelay(el, vnode)).toEqual(expect.objectContaining({ local: { input: 200 } }));
+  expect(Generator.resolveDelay(el, {}, { delay: '300' })).toEqual({ global: 300 });
 })
 
 test('resolves events', () => {
@@ -85,10 +85,10 @@ test('resolves events', () => {
   `;
   let el = document.querySelector('#el');
   const vnode = { child: { $attrs: { 'data-vv-validate-on': 'focus' } } };
-  expect(Generator.resolveEvents(el, {})).toBe('input');
+  expect(Generator.resolveEvents(el, {})).toBe("input");
   el = { getAttribute: () => null };
 
-  expect(Generator.resolveEvents(el, vnode)).toBe('focus');
+  expect(Generator.resolveEvents(el, vnode)).toBe("focus");
 });
 
 test('resolves alias', () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -135,7 +135,7 @@ test('toggles classes', () => {
 
   utils.toggleClass(el, 'some', false);
   expect(utils.hasClass(el, 'some')).toBe(false);
-  
+
   expect(() => {
     utils.toggleClass(el, null, true);
   }).not.toThrow();
@@ -185,7 +185,7 @@ test('gets the value path with a fallback value', () => {
 
   expect(utils.getPath(null, some)).toBe(undefined); // no path.
   expect(utils.getPath('value.val', null)).toBe(undefined); // no object.
-  
+
   expect(utils.getPath('value.val', some)).toBe(1); // exists.
   expect(utils.getPath('value.path', some)).toBe(undefined); // undefined but exists.
   expect(utils.getPath('value.not', some, false)).toBe(false); // does not.
@@ -390,4 +390,66 @@ describe('pareses date values', () => {
     expect(dateUtils.parseDate(Date.parse('foo'), format)).toBe(null);
   });
 
+});
+
+describe('makeEventsArray', () => {
+  test('it creates valid event arrays', () => {
+    expect(utils.makeEventsArray('input|blur|change')).toEqual(['input', 'blur', 'change']);
+    expect(utils.makeEventsArray('focus')).toEqual(['focus'])
+  });
+
+  test('it handles empty event strings', () => {
+    expect(utils.makeEventsArray('')).toEqual([]);
+  });
+
+  test('it handles invalid event strings', () => {
+    expect(utils.makeEventsArray('input, focus')).not.toEqual(['input', 'focus']);
+    expect(utils.makeEventsArray('blur/change')).toEqual(['blur/change']);
+  });
+});
+
+describe('makeDelayObject', () => {
+  test('it handles delays from an object under the global key', () => {
+    expect(utils.makeDelayObject(['input', 'blur'], {global: {input: 100, blur: 200}})).toEqual({input: 100, blur: 200});
+    expect(utils.makeDelayObject(['change'], {global: {change: 100}})).toEqual({change: 100});
+  });
+
+  test('it handles delays from an object under the local key', () => {
+    expect(utils.makeDelayObject(['input'], {local: {input: 100}})).toEqual({input: 100});
+  });
+
+  test('it handles overwrites values from the global key with those from local key', () => {
+    expect(utils.makeDelayObject(['input'], {local: {input: 100}, global: {input: 500}})).toEqual({input: 100});
+    expect(utils.makeDelayObject(['input', 'blur'], {local: {input: 600}, global: {input: 200, blur: 400}})).toEqual({input: 600, blur: 400});
+  });
+
+  test('it handles all events and sets them to 0', () => {
+    expect(utils.makeDelayObject(['change', 'blur', 'focus'], {})).toEqual({change: 0, blur: 0, focus: 0});
+  });
+
+  test('it handles empty events', () => {
+    expect(utils.makeDelayObject([], {global: {input: 100}})).toEqual({});
+  });
+
+  test('it handles empty given objects', () => {
+    expect(utils.makeDelayObject(['input'], {})).toEqual({input: 0});
+  });
+
+  test('it handles empty events and empty given objects together', () => {
+    expect(utils.makeDelayObject([], {})).toEqual({});
+  });
+
+  test('it handles already valid delay objects', () => {
+    expect(utils.makeDelayObject(['input', 'blur'], {change: 200, focus: 800})).toEqual({change: 200, focus: 800});
+  });
+
+  test('it handles delay integers', () => {
+    expect(utils.makeDelayObject(['focus', 'input'], 600)).toEqual({focus: 600, input: 600});
+  });
+});
+
+describe('deepParseInt', () => {
+  test('it parses all values on the first level of an object to int', () => {
+    expect(utils.deepParseInt({ blur: "10", input: "400", focus: 300, change: "hello" })).toEqual({ blur: 10, input: 400, focus: 300, change: NaN });
+  });
 });


### PR DESCRIPTION
As mentioned by @ssendev in #620 the validation delay does not make a lot of sense on blur. The primary objective of the delay would pretty much always be to stop error messages while typing. Since the blur event needs to be triggered by the user manually, there is no point in applying the delay there too.

Of course, the topic of #620 originally was more complex: The delay and events should be dynamic based on the status of the field. It makes a lot of sense, but it does require more changes.

Now I will admit, my solution is all but ideal, but it works (locally tested) and it does solve the issue. I do hope it can be improved further (config option, separate delay for blur events, less awful code).

Since the code quality isn't great and I couldn't figure out how to properly test specific event delays I don't think it should be merged necessarily. If anyone needs this feature in this hacky form, they can use my repo and ``npm link`` locally.

- [x] Disable delay on ``blur``
- [x] Make the behaviour of ``blur`` configurable
- [x] Allow configuration of delays on a per event basis
- [x] Write documentation