### PR TITLE
[WIP] Improve test coverage to 100%

### DIFF
--- a/src/core/errorBag.js
+++ b/src/core/errorBag.js
@@ -97,7 +97,7 @@ export default class ErrorBag {
       return collection;
     }
 
-    field = !isNullOrUndefined(field) ? String(field) : field;
+    field = String(field);
     if (isNullOrUndefined(scope)) {
       return this.items.filter(e => e.field === field).map(e => (map ? e.msg : e));
     }
@@ -125,7 +125,8 @@ export default class ErrorBag {
    * Gets the first error message for a specific field.
    */
   first (field: string, scope ?: ?string = null) {
-    field = !isNullOrUndefined(field) ? String(field) : field;
+    if (isNullOrUndefined(field)) return null;
+    field = String(field);
     const selector = this._selector(field);
     const scoped = this._scope(field);
 

--- a/tests/errorBag.js
+++ b/tests/errorBag.js
@@ -74,6 +74,8 @@ test('removes errors by matching against the field id', () => {
     scope: 's1'
   })
   expect(errors.count()).toBe(1);
+  errors.removeById('unknown');
+  expect(errors.count()).toBe(1);
   errors.removeById('myId');
   expect(errors.count()).toBe(0);
 });
@@ -177,6 +179,10 @@ test('fetches the first error message for a specific field', () => {
   errors.add('email', 'mah', 'rule2', 'scope2');
   expect(errors.first('scope1.email')).toBe('nah');
   expect(errors.first('scope2.email:rule2')).toBe('mah');
+
+  // no field given
+  expect(errors.first()).toBe(null);
+  expect(errors.first(null)).toBe(null);
 });
 
 test('fetches the first error message for a specific field that not match the rule', () => {
@@ -189,6 +195,7 @@ test('fetches the first error message for a specific field that not match the ru
   errors.add('email', 'This is the third rule', 'rule2');
   errors.add('email', 'This is the forth rule', 'rule2');
 
+  expect(errors.firstNot('unknown')).toBeNull();
   expect(errors.firstNot('email')).toBe('The email is invalid');
   expect(errors.firstNot('email', 'rule1')).toBe('The email is required');
 });

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -377,3 +377,9 @@ test('generates fake vm', () => {
   expect(vm.$el).toBe('this is an el');
   expect(vm.$refs.myref).toBe(1);
 });
+
+describe('getCtorConfig', () => {
+  test('it returns null if no child component is given', () => {
+    expect(Generator.getCtorConfig({})).toBeNull();
+  });
+});

--- a/tests/rules/date_between.js
+++ b/tests/rules/date_between.js
@@ -20,6 +20,7 @@ test('checks if a date is between two other dates - left inclusive', () => {
   const format = 'DD/MM/YYYY';
 
   expect(validate('01/09/2016', ['01/09/2016', '20/09/2016', '[)', format])).toBe(true);
+  expect(validate('10/09/2016', ['01/09/2016', '20/09/2016', '[)', format])).toBe(true);
   expect(validate('20/09/2016', ['01/09/2016', '20/09/2016', '[)', format])).toBe(false);
 });
 
@@ -27,6 +28,7 @@ test('checks if a date is between two other dates - right inclusive', () => {
   const format = 'DD/MM/YYYY';
 
   expect(validate('01/09/2016', ['01/09/2016', '20/09/2016', '(]', format])).toBe(false);
+  expect(validate('10/09/2016', ['01/09/2016', '20/09/2016', '(]', format])).toBe(true);
   expect(validate('20/09/2016', ['01/09/2016', '20/09/2016', '(]', format])).toBe(true);
 });
 
@@ -35,5 +37,6 @@ test('checks if a date is between two other dates - all inclusive', () => {
   const format = 'DD/MM/YYYY';
 
   expect(validate('01/09/2016', ['01/09/2016', '20/09/2016', '[]', format])).toBe(true);
+  expect(validate('10/09/2016', ['01/09/2016', '20/09/2016', '[]', format])).toBe(true);
   expect(validate('20/09/2016', ['01/09/2016', '20/09/2016', '[]', format])).toBe(true);
 });


### PR DESCRIPTION
I've started with the process of getting the test coverage up to 100%. I think after the coverage is up, a refactor of a large portion of the tests is needed. They seem to be all over the place in terms of writing style and structure and some of them don't do anything.

An example of a test that is useless can be found in ``utils/index.js``, where the following exists:

```JavaScript
// test polyfill.
let arr = Array.from(nodeList);
arr.find = undefined;
expect(find(arr, el => el.name === 'i1')).toBe(el);
```

This is supposed to test the polyfill of ``utils.find``, which is essentially ``array.find``. However, in ``utils.find`` the input array parameter is handled like this:

```JavaScript
const array = toArray(arrayLike);
```

This negates the effect of ``arr.find = undefined;``, since it re-adds the method to the array. This is just supposed to be an example. Ideally all functions of a file should have their own describe block and there should be sensible setup functions.

This PR is supposed to address coverage though, so the test refactor may or may not be a project for the future that is worth considering.

- [x] errorBag.js
- [x] generator.js
- [x] date_between.js
- [ ] mixin.js
- [ ] field.js
- [ ] validator.js
- [ ] utils/index.js