### PR TITLE
Incorrect spelling in document

### DIFF
--- a/docs/examples.html
+++ b/docs/examples.html
@@ -474,8 +474,8 @@ export default {
 <ul>
 <li><code>touched</code>: indicates that the field has been touched or focused.</li>
 <li><code>untouched</code>: indicates that the field has not been touched nor focused.</li>
-<li><code>dirty</code>: indicates that the field has been manipluated.</li>
-<li><code>pristine</code>: indicates that the field has not been manipluated.</li>
+<li><code>dirty</code>: indicates that the field has been manipulated.</li>
+<li><code>pristine</code>: indicates that the field has not been manipulated.</li>
 <li><code>valid</code>: indicates that the field has been validated at least once and that it passed the validation.</li>
 <li><code>invalid</code>: indicates that the field has been validated at least once and that it failed the validation.</li>
 </ul>

--- a/docs/src/templates/markdown/examples/flags.md
+++ b/docs/src/templates/markdown/examples/flags.md
@@ -5,8 +5,8 @@ vee-validate includes few flags that could help you improve your user experience
 
 - `touched`: indicates that the field has been touched or focused.
 - `untouched`: indicates that the field has not been touched nor focused.
-- `dirty`: indicates that the field has been manipluated.
-- `pristine`: indicates that the field has not been manipluated.
+- `dirty`: indicates that the field has been manipulated.
+- `pristine`: indicates that the field has not been manipulated.
 - `valid`: indicates that the field has been validated at least once and that it passed the validation.
 - `invalid`: indicates that the field has been validated at least once and that it failed the validation.
 


### PR DESCRIPTION
Fixed incorrect spelling in documents.

- What:
`manipluated` must be `manipulated`

- Where:
http://vee-validate.logaretm.com/examples.html#flags-example