### PR TITLE
Fix Memory leak in SSR

### DIFF
--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -28,7 +28,7 @@ export default class Validator {
 
     // We are running in SSR Mode. Do not keep a reference. It prevent garbage collection.
     if (typeof window !== 'undefined') {
-       ERRORS.push(this.errors);
+      ERRORS.push(this.errors);
     }
     this.fields = new FieldBag();
     this.flags = {};

--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -25,7 +25,11 @@ export default class Validator {
   constructor (validations?: MapObject, options?: MapObject = { vm: null, fastExit: true }) {
     this.strict = STRICT_MODE;
     this.errors = new ErrorBag();
-    ERRORS.push(this.errors);
+
+    // We are running in SSR Mode. Do not keep a reference. It prevent garbage collection.
+    if (typeof window !== 'undefined') {
+       ERRORS.push(this.errors);
+    }
     this.fields = new FieldBag();
     this.flags = {};
     this._createFields(validations);


### PR DESCRIPTION
The global ERROR object keeps references to the errors objects.
This prevent the garbage collector from freeing the memory.

This fix simply check if a window exists (if yes we are running in the browser) else we are in SSR.
Do not add the error object to the ERROR const global variable to allow GC cleanup.