### PR TITLE
Fixed example on index page.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@ ga('send', 'pageview');
   &lt;script src=&quot;https://cdn.jsdelivr.net/npm/vee-validate@latest/dist/vee-validate.js&quot;&gt;&lt;/script&gt;
 
   &lt;!-- unpkg --&gt;
-  &lt;script src=&quot;https://unpkg.com/vee-validate@2.0.0-rc.7)&quot;&gt;&lt;/script&gt;
+  &lt;script src=&quot;https://unpkg.com/vee-validate@2.0.0-rc.7&quot;&gt;&lt;/script&gt;
 </code></pre>
 <h3><a href="#usage">Usage</a></h3>
 <pre><code class="highlight-html">  &lt;script src=&quot;path/to/vue.js&quot;&gt;&lt;/script&gt;


### PR DESCRIPTION
Removed bracket at the end of the https://unpkg.com/vee-validate@2.0.0-rc.7 url.