### PR TITLE
fix #1179

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -1,8 +1,8 @@
 import Vue = require("vue")
 
 declare enum ValidatorResolveStrategy {
-    new = 'new',
-    inherit = 'inherit'
+    new,
+    inherit
 }
 
 export interface VeeValidateComponentOptions {


### PR DESCRIPTION
fix #1179
change enum declaration to avoid typescript error "TS1066: In ambient enum declarations member initializer must be constant expression"