### PR TITLE
Move dev-only libraries to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
     "types/*.d.ts"
   ],
   "devDependencies": {
+    "@vue/test-utils": "^1.0.0-beta.12",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "chalk": "^2.1.0",
     "cross-env": "^5.0.5",
@@ -103,8 +105,5 @@
       ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
     }
   },
-  "dependencies": {
-    "@vue/test-utils": "^1.0.0-beta.12",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
- `@vue/test-utils` is used only for tests
- `babel-plugin-transform-object-rest-spread` is used only for build