### PR TITLE
[WIP] Rules from html attributes

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -178,15 +178,19 @@ export const debounce = (fn: () => any, wait: number = 0, immediate: boolean = f
   };
 };
 
-export const appendRule = (rule, rules) => {
+/**
+ * Appends a rule definition to a list of rules.
+ */
+export const appendRule = (rule: string, rules: string | { [string]: boolean | any[] }) => {
+  if (!rules) {
+    return rule;
+  }
+
   if (typeof rules === 'string') {
     return `${rules}|${rule}`;
   }
 
-  return {
-    ...rules,
-    ...normalizeRules(rule)
-  };
+  return assign({}, rules, normalizeRules(rule));
 };
 
 /**

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -178,6 +178,17 @@ export const debounce = (fn: () => any, wait: number = 0, immediate: boolean = f
   };
 };
 
+export const appendRule = (rule, rules) => {
+  if (typeof rules === 'string') {
+    return `${rules}|${rule}`;
+  }
+
+  return {
+    ...rules,
+    ...normalizeRules(rule)
+  };
+};
+
 /**
  * Normalizes the given rules expression.
  */

--- a/tests/unit/generator.js
+++ b/tests/unit/generator.js
@@ -46,10 +46,24 @@ describe('resolves the rules', () => {
         }
       }
     };
-  
+
     expect(Generator.resolveRules(el, directive)).toEqual({
       required: true,
       email: true
     });
+  });
+
+  test('using HTML5 validation Attributes', () => {
+    const input = document.createElement('input');
+    input.type = 'email';
+    input.required = true;
+
+    expect(Generator.resolveRules(input, {})).toBe('required|email');
+
+    input.type = 'number';
+    input.required = false;
+    input.min = 10;
+    input.max = 20;
+    expect(Generator.resolveRules(input, {})).toBe('decimal|min_value:10|max_value:20');
   });
 });


### PR DESCRIPTION
This adds another source of rules for vee-validate, it allows the plugin to pull rules from native HTML5 elements using [HTML form validation API](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation)

For example:

```html
<input type="email" name="field" v-model="val" required v-validate>
```

This will validate the field with the following rules: `required` and `email`.

Here is a table of attributes that translates to a rule:

| Attribute Name |   value      | Rule           |
| ------------- |:-------------:|
| type      | "email" |  "email"  |
| type      | "number"  |  "decimal"  |
| min | val |  min_value: val |
| max | val | max_value: val |
| pattern | rgx | regex: rgx |

As I am working on this, more rules can be added in the future.