### PR TITLE
Fix Turkish conjunction combined spelling mistake

### DIFF
--- a/locale/tr.js
+++ b/locale/tr.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `${field} numarası hatalı.`,
   date_between: (field, [min, max]) => `${field} ${min} ile ${max} tarihleri arasında olmalıdır.`,
   date_format: (field, [format]) => `${field} ${format} formatında olmalıdır.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} sayısal${decimals !== '*' ? `ve noktadan sonra ${decimals} basamaklı` : ''} olmalıdır.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} sayısal${decimals !== '*' ? ` ve noktadan sonra ${decimals} basamaklı` : ''} olmalıdır.`,
   digits: (field, [length]) => `${field} sayısal ve ${length} basamaklı olmalıdır.`,
   dimensions: (field, [width, height]) => `${field} alanı ${width} piksel ile ${height} piksel arasında olmalıdır.`,
   email: (field) => `${field} alanının geçerli bir e-posta olması gerekir.`,


### PR DESCRIPTION
Turkish 've(and)' the conjunction is written in combined. The spelling error was corrected because it was a separate word.