### PR TITLE
Error Bag consistency fix

### DIFF
--- a/src/core/errorBag.js
+++ b/src/core/errorBag.js
@@ -1,4 +1,4 @@
-import { find, isNullOrUndefined, isCallable } from './utils';
+import { find, isNullOrUndefined, isCallable, warn } from './utils';
 
 // @flow
 
@@ -24,6 +24,7 @@ export default class ErrorBag {
   add (error: FieldError | FieldError[]) {
     // handle old signature.
     if (arguments.length > 1) {
+      warn('This usage of "errors.add()" is deprecated, please consult the docs for the new signature.');
       error = {
         field: arguments[0],
         msg: arguments[1],
@@ -134,14 +135,22 @@ export default class ErrorBag {
       return collection;
     }
 
-    field = !isNullOrUndefined(field) ? String(field) : field;
-    if (isNullOrUndefined(scope)) {
-      return this.items.filter(e => e.field === field).map(e => (map ? e.msg : e));
+    if (isNullOrUndefined(field)) {
+      return [];
     }
 
-    return this.items.filter(e => e.field === field && e.scope === scope)
-      .map(e => (map ? e.msg : e));
+    const selector = isNullOrUndefined(scope) ? String(field) : `${scope}.${field}`;
+    const { isPrimary } = this._makeCandidateFilters(selector);
+
+    return this.items.reduce((prev, curr) => {
+      if (isPrimary(curr)) {
+        prev.push(map ? curr.msg : curr);
+      }
+
+      return prev;
+    }, []);
   }
+
   /**
    * Gets the internal array length.
    */
@@ -155,41 +164,17 @@ export default class ErrorBag {
   firstById (id: string): string | null {
     const error = find(this.items, i => i.id === id);
 
-    return error ? error.msg : null;
+    return error ? error.msg : undefined;
   }
 
   /**
    * Gets the first error message for a specific field.
    */
   first (field: string, scope ?: ?string = null) {
-    if (isNullOrUndefined(field)) {
-      return null;
-    }
+    const selector = isNullOrUndefined(scope) ? field : `${scope}.${field}`;
+    const match = this._match(selector);
 
-    field = String(field);
-    const selector = this._selector(field);
-    const scoped = this._scope(field);
-
-    if (scoped) {
-      const result = this.first(scoped.name, scoped.scope);
-      // if such result exist, return it. otherwise it could be a field.
-      // with dot in its name.
-      if (result) {
-        return result;
-      }
-    }
-
-    if (selector) {
-      return this.firstByRule(selector.name, selector.rule, scope);
-    }
-
-    for (let i = 0; i < this.items.length; ++i) {
-      if (this.items[i].field === field && (this.items[i].scope === scope)) {
-        return this.items[i].msg;
-      }
-    }
-
-    return null;
+    return match && match.msg;
   }
 
   /**
@@ -198,7 +183,7 @@ export default class ErrorBag {
   firstRule (field: string, scope ?: string): string | null {
     const errors = this.collect(field, scope, false);
 
-    return (errors.length && errors[0].rule) || null;
+    return (errors.length && errors[0].rule) || undefined;
   }
 
   /**
@@ -214,7 +199,7 @@ export default class ErrorBag {
   firstByRule (name: string, rule: string, scope?: string | null = null) {
     const error = this.collect(name, scope, false).filter(e => e.rule === rule)[0];
 
-    return (error && error.msg) || null;
+    return (error && error.msg) || undefined;
   }
 
   /**
@@ -223,7 +208,7 @@ export default class ErrorBag {
   firstNot (name: string, rule?: string = 'required', scope?: string | null = null) {
     const error = this.collect(name, scope, false).filter(e => e.rule !== rule)[0];
 
-    return (error && error.msg) || null;
+    return (error && error.msg) || undefined;
   }
 
   /**
@@ -248,46 +233,92 @@ export default class ErrorBag {
    * Removes all error messages associated with a specific field.
    */
   remove (field: string, scope: ?string) {
-    field = !isNullOrUndefined(field) ? String(field) : field;
-    const removeCondition = (e: FieldError) => {
-      if (!isNullOrUndefined(scope)) {
-        return e.field === field && e.scope === scope;
-      }
+    if (isNullOrUndefined(field)) {
+      return;
+    }
 
-      return e.field === field && e.scope === null;
-    };
+    const selector = isNullOrUndefined(scope) ? String(field) : `${scope}.${field}`;
+    const { isPrimary } = this._makeCandidateFilters(selector);
 
     for (let i = 0; i < this.items.length; ++i) {
-      if (removeCondition(this.items[i])) {
+      if (isPrimary(this.items[i])) {
         this.items.splice(i, 1);
         --i;
       }
     }
   }
 
-  /**
-   * Get the field attributes if there's a rule selector.
-   */
-  _selector (field: string): { name: string, rule: string } | null {
-    if (field.indexOf(':') > -1) {
-      const [name, rule] = field.split(':');
+  _makeCandidateFilters (selector) {
+    let matchesRule = () => true;
+    let matchesScope = () => true;
+    let matchesName = () => true;
 
-      return { name, rule };
+    let [, scope, name, rule] = selector.match(/((?:[\w-])+\.)?((?:[\w-.])+)(:\w+)?/);
+    if (rule) {
+      rule = rule.replace(':', '');
+      matchesRule = (item) => item.rule === rule;
     }
 
-    return null;
-  }
-
-  /**
-   * Get the field scope if specified using dot notation.
-   */
-  _scope (field: string): { name: string, scope: string } | null {
-    if (field.indexOf('.') > -1) {
-      const [scope, ...name] = field.split('.');
-
-      return { name: name.join('.'), scope };
+    // match by id, can be combined with rule selection.
+    if (selector.startsWith('#')) {
+      return item => matchesRule(item) && (item => selector.slice(1).startsWith(item.id));
     }
 
-    return null;
+    if (isNullOrUndefined(scope)) {
+      // if no scope specified, make sure the found error has no scope.
+      matchesScope = item => isNullOrUndefined(item.scope);
+    } else {
+      scope = scope.replace('.', '');
+      matchesScope = item => item.scope === scope;
+    }
+
+    if (!(isNullOrUndefined(name))) {
+      matchesName = item => item.field === name;
+    }
+
+    // matches the first candidate.
+    const isPrimary = (item) => {
+      return matchesName(item) && matchesRule(item) && matchesScope(item);
+    };
+
+    // matches a second candidate, which is a field with a name containing the '.' character.
+    const isAlt = (item) => {
+      return matchesRule(item) && item.field === `${scope}.${name}`;
+    };
+
+    return {
+      isPrimary,
+      isAlt
+    };
   }
+
+  _match (selector: string) {
+    if (isNullOrUndefined(selector)) {
+      return undefined;
+    }
+
+    const { isPrimary, isAlt } = this._makeCandidateFilters(selector);
+
+    return this.items.reduce((prev, item, idx, arr) => {
+      const isLast = idx === arr.length - 1;
+      if (prev.primary) {
+        return isLast ? prev.primary : prev;
+      }
+
+      if (isPrimary(item)) {
+        prev.primary = item;
+      }
+
+      if (isAlt(item)) {
+        prev.alt = item;
+      }
+
+      // keep going.
+      if (!isLast) {
+        return prev;
+      }
+
+      return prev.primary || prev.alt;
+    }, {});
+  };
 }

--- a/src/core/errorBag.js
+++ b/src/core/errorBag.js
@@ -140,15 +140,21 @@ export default class ErrorBag {
     }
 
     const selector = isNullOrUndefined(scope) ? String(field) : `${scope}.${field}`;
-    const { isPrimary } = this._makeCandidateFilters(selector);
+    const { isPrimary, isAlt } = this._makeCandidateFilters(selector);
 
-    return this.items.reduce((prev, curr) => {
+    const collected = this.items.reduce((prev, curr) => {
       if (isPrimary(curr)) {
-        prev.push(map ? curr.msg : curr);
+        prev.primary.push(map ? curr.msg : curr);
+      }
+
+      if (isAlt(curr)) {
+        prev.alt.push(map ? curr.msg : curr);
       }
 
       return prev;
-    }, []);
+    }, { primary: [], alt: [] });
+
+    return collected.primary.length ? collected.primary : collected.alt;
   }
 
   /**

--- a/src/core/errorBag.js
+++ b/src/core/errorBag.js
@@ -267,7 +267,10 @@ export default class ErrorBag {
 
     // match by id, can be combined with rule selection.
     if (selector.startsWith('#')) {
-      return item => matchesRule(item) && (item => selector.slice(1).startsWith(item.id));
+      return {
+        isPrimary: item => matchesRule(item) && (item => selector.slice(1).startsWith(item.id)),
+        isAlt: () => false
+      };
     }
 
     if (isNullOrUndefined(scope)) {

--- a/src/core/errorBag.js
+++ b/src/core/errorBag.js
@@ -122,7 +122,7 @@ export default class ErrorBag {
    * Collects errors into groups or for a specific field.
    */
   collect (field?: string, scope?: string | null, map?: boolean = true) {
-    if (!field) {
+    if (isNullOrUndefined(field)) {
       const collection = {};
       this.items.forEach(e => {
         if (! collection[e.field]) {
@@ -133,10 +133,6 @@ export default class ErrorBag {
       });
 
       return collection;
-    }
-
-    if (isNullOrUndefined(field)) {
-      return [];
     }
 
     const selector = isNullOrUndefined(scope) ? String(field) : `${scope}.${field}`;

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -115,11 +115,11 @@ export const getScope = (el: HTMLInputElement) => {
  * Get the closest form element.
  */
 export const getForm = (el: HTMLInputElement) => {
-  if (isNullOrUndefined(el)) { return null; }
+  if (isNullOrUndefined(el)) return null;
 
-  if (el.tagName === 'FORM') { return el; }
+  if (el.tagName === 'FORM') return el;
 
-  if (!isNullOrUndefined(el.form)) { return el.form; };
+  if (!isNullOrUndefined(el.form)) return el.form;
 
   return !isNullOrUndefined(el.parentNode) ? getForm(el.parentNode) : null;
 };

--- a/tests/unit/errorBag.js
+++ b/tests/unit/errorBag.js
@@ -61,8 +61,18 @@ test('finds error messages by matching against field id', () => {
     rule: 'r1',
     scope: 's1'
   });
+  errors.add({
+    id: 'myId',
+    field: 'name',
+    msg: 'There',
+    rule: 'r2',
+    scope: 's1'
+  });
   expect(errors.firstById('someId')).toBe(undefined);
   expect(errors.firstById('myId')).toBe('Hey');
+
+  expect(errors.first('#myId:r1')).toBe('Hey');
+  expect(errors.first('#myId:r2')).toBe('There');
 });
 
 test('removes errors for a specific field', () => {

--- a/tests/unit/errorBag.js
+++ b/tests/unit/errorBag.js
@@ -19,7 +19,7 @@ test('adds errors to the collection', () => {
   expect(errors.first('name', 's1')).toBe('Hey');
 
   // handles undefined params
-  expect(errors.first()).toBe(null);
+  expect(errors.first()).toBe(undefined);
 });
 
 test('accepts an array of errors', () => {
@@ -61,7 +61,7 @@ test('finds error messages by matching against field id', () => {
     rule: 'r1',
     scope: 's1'
   });
-  expect(errors.firstById('someId')).toBe(null);
+  expect(errors.firstById('someId')).toBe(undefined);
   expect(errors.firstById('myId')).toBe('Hey');
 });
 
@@ -132,14 +132,6 @@ test('clears the errors within a scope', () => {
   expect(errors.count()).toBe(1);
 });
 
-test('checks for field selector existence', () => {
-  const errors = new ErrorBag();
-
-  expect(errors._selector('name:rule').name).toBe('name');
-  expect(errors._selector('name:rule').rule).toBe('rule');
-  expect(errors._selector('name')).toBe(null);
-});
-
 test('checks for field error existence', () => {
   const errors = new ErrorBag();
   errors.add('name', 'The name is invalid', 'rule1');
@@ -183,7 +175,7 @@ test('fetches the first error message for a specific field', () => {
   errors.add('email', 'The email is shorter than 3 chars.', 'rule1');
 
   expect(errors.first('email')).toBe('The email is shorter than 3 chars.');
-  expect(errors.first('name')).toBe(null);
+  expect(errors.first('name')).toBe(undefined);
 
   // test dot notation.
   errors.add('email', 'nah', 'rule2', 'scope1');
@@ -214,8 +206,8 @@ test('fetches the first error rule for a specific field', () => {
 
   expect(errors.firstRule('email')).toBe('rule1');
   expect(errors.firstRule('name')).toBe('rule2');
-  expect(errors.firstRule('email', 'scope3')).toBe(null);
-  expect(errors.firstRule('password')).toBe(null);
+  expect(errors.firstRule('email', 'scope3')).toBe(undefined);
+  expect(errors.firstRule('password')).toBe(undefined);
 });
 
 test('fetches the first error message for a specific scoped field', () => {
@@ -225,7 +217,7 @@ test('fetches the first error message for a specific scoped field', () => {
 
   expect(errors.first('email', 'scope1')).toBe('The email is invalid');
   expect(errors.first('email', 'scope2')).toBe('The email is shorter than 3 chars.');
-  expect(errors.first('email', 'scope3')).toBe(null);
+  expect(errors.first('email', 'scope3')).toBe(undefined);
 });
 
 test('returns all errors in an array', () => {
@@ -342,7 +334,7 @@ test('can get a specific error message for a specific rule', () => {
 
   expect(errors.firstByRule('name', 'rule1')).toBe('The name is invalid');
   expect(errors.firstByRule('name', 'rule2')).toBe('The name is really invalid');
-  expect(errors.firstByRule('email', 'rule1')).toBe(null);
+  expect(errors.firstByRule('email', 'rule1')).toBe(undefined);
 });
 
 test('fetches both scoped names and names with dots', () => {

--- a/tests/unit/errorBag.js
+++ b/tests/unit/errorBag.js
@@ -260,14 +260,16 @@ test('collects errors for a specific field in an array', () => {
   expect(~errors.collect('name').indexOf('The name is invalid')).toBeTruthy();
 });
 
-test('collects all errors across scopes if no scope is defined', () => {
+test('exactly matches the collected field name', () => {
   const errors = new ErrorBag();
-  errors.add('name', 'The name is invalid', 'rule1');
+  errors.add('name', 'The name is invalid', 'rule1'); // no scope
   errors.add('name', 'The name is invalid', 'rule1', 'scope1');
+  errors.add('name', 'The name is invalid', 'rule2', 'scope1');
   errors.add('name', 'The name is invalid', 'rule1', 'scope2');
 
-  expect(errors.collect('name').length).toBe(3);
+  expect(errors.collect('name').length).toBe(1); // should find the non-scoped one.
   expect(errors.collect('name', 'scope2').length).toBe(1);
+  expect(errors.collect('scope1.name').length).toBe(2); // supports selectors.
 });
 
 test('collects errors for a specific field and scope', () => {

--- a/tests/unit/errorBag.js
+++ b/tests/unit/errorBag.js
@@ -297,6 +297,17 @@ test('collects errors for a specific field and scope', () => {
   ).toBeTruthy();
 });
 
+test('collects dotted field names', () => {
+  const errors = new ErrorBag();
+  errors.add('scope.email', 'The email is not email', 'rule1');
+  errors.add('scope.email', 'The email is invalid', 'rule1');
+
+  expect(errors.collect('scope.email')).toEqual([
+    'The email is not email',
+    'The email is invalid',
+  ]);
+});
+
 test('groups errors by field name', () => {
   const errors = new ErrorBag();
   errors.add('name', 'The name is invalid', 'rule1');


### PR DESCRIPTION
#### Overview

This PR refactors the matching behavior of error items to be more re-usable. The matching function will be re-used with `errors.collect` and `errors.remove`.

Also introduces a tiny perf gain with large error bag items count since it doesn't search twice for fields with dots in their name.

#### Issues affected

closes #1322, closes #1317
