### PR TITLE
Fixes isBuiltInComponent check.

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -415,7 +415,7 @@ export const isBuiltInComponent = (vnode: Object): boolean => {
 
   const tag = vnode.componentOptions.tag;
 
-  return /keep-alive|transition|transition-group/.test(tag);
+  return /^(keep-alive|transition|transition-group)$/.test(tag);
 };
 
 export const makeEventsArray = (events: string) => {


### PR DESCRIPTION
Previously it detected components which included built-in component tags as substrings. E.g. it detected 'my-transition-component' as a built-in.