### PR TITLE
improve model detection

### DIFF
--- a/tests/integration/components/Model.vue
+++ b/tests/integration/components/Model.vue
@@ -4,6 +4,8 @@
     <input type="text" name="unwatchablefield" v-validate="'required'" v-model="form['value']" id="unwatchable">
     <input type="text" name="argField" v-validate:input="'required'" v-model="input">
     <child-with-model v-model="value" v-validate="'required'" data-vv-name="customModel"></child-with-model>
+
+    <child-with-model v-for="(val, n) in values" :key="n" v-model="val.value" v-validate="'required'" :data-vv-name="`loop[${n}]`"></child-with-model>
   </div>
 </template>
 
@@ -20,7 +22,10 @@ export default {
     input: null,
     form: {
       value: null
-    }
+    },
+    values: [
+      { value: null }
+    ]
   })
 };
 </script>

--- a/tests/integration/components/Model.vue
+++ b/tests/integration/components/Model.vue
@@ -3,12 +3,18 @@
     <input type="text" name="field" v-validate="'required'" v-model="value" id="watchable">
     <input type="text" name="unwatchablefield" v-validate="'required'" v-model="form['value']" id="unwatchable">
     <input type="text" name="argField" v-validate:input="'required'" v-model="input">
+    <child-with-model v-model="value" v-validate="'required'" data-vv-name="customModel"></child-with-model>
   </div>
 </template>
 
 <script>
+import ChildWithModel from './stubs/ChildWithModel';
+
 export default {
   name: 'model-test',
+  components: {
+    ChildWithModel
+  },
   data: () => ({
     value: null,
     input: null,

--- a/tests/integration/components/stubs/ChildWithModel.vue
+++ b/tests/integration/components/stubs/ChildWithModel.vue
@@ -1,0 +1,16 @@
+<template>
+  <div></div>
+</template>
+
+
+<script>
+export default {
+  model: {
+    prop: 'innerValue',
+    event: 'change'
+  },
+  props: {
+    innerValue: null
+  }
+}
+</script>

--- a/tests/integration/model.js
+++ b/tests/integration/model.js
@@ -1,4 +1,4 @@
-import { shallow, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import VeeValidate from '@/index';
 import TestComponent from './components/Model';
@@ -7,7 +7,7 @@ const Vue = createLocalVue();
 Vue.use(VeeValidate);
 
 test('watches input value on model change', async () => {
-  const wrapper = shallow(TestComponent, { localVue: Vue });
+  const wrapper = mount(TestComponent, { localVue: Vue });
   expect(wrapper.vm.errors.count()).toBe(0);
   wrapper.setData({ value: '' });
   await flushPromises();
@@ -15,17 +15,15 @@ test('watches input value on model change', async () => {
 });
 
 test('model can be watched via the directive arg', async() => {
-  const wrapper = shallow(TestComponent, { localVue: Vue });
+  const wrapper = mount(TestComponent, { localVue: Vue });
   expect(wrapper.vm.errors.has('argField')).toBe(false);
   wrapper.setData({ input: '' });
   await flushPromises();
   expect(wrapper.vm.errors.has('argField')).toBe(true);
 });
 
-
-
 test('falls back to DOM events if the model is unwatchable', async() => {
-  const wrapper = shallow(TestComponent, { localVue: Vue });
+  const wrapper = mount(TestComponent, { localVue: Vue });
   expect(wrapper.vm.errors.count()).toBe(0);
   wrapper.setData({
     form: {
@@ -38,5 +36,12 @@ test('falls back to DOM events if the model is unwatchable', async() => {
   wrapper.find('#unwatchable').trigger('input');
   await flushPromises();
   expect(wrapper.vm.errors.has('unwatchablefield')).toBe(true);
+});
+
+test('detects the model config on the component ctor options', async () => {
+  const wrapper = mount(TestComponent, { localVue: Vue });
+  const field = wrapper.vm.$validator.fields.find({ name: 'customModel' });
+
+  expect(field.events).toEqual(['change']);
 });
 

--- a/tests/integration/model.js
+++ b/tests/integration/model.js
@@ -45,3 +45,30 @@ test('detects the model config on the component ctor options', async () => {
   expect(field.events).toEqual(['change']);
 });
 
+test('watches the model from the child context if it cannot be watched from the parent', async () => {
+  const wrapper = mount(TestComponent, { localVue: Vue });
+  const field = wrapper.vm.$validator.fields.find({ name: 'loop[0]' });
+
+  expect(field.events).toEqual(['change']);
+  wrapper.setData({
+    values: [
+      { value: 'someval' }
+    ]
+  });
+
+  await flushPromises();
+
+  // check resolving
+  expect(field.value).toBe('someval');
+  expect(wrapper.vm.$validator.errors.count()).toBe(0);
+
+  // check watchers
+  wrapper.setData({
+    values: [
+      { value: '' }
+    ]
+  });
+  await flushPromises();
+  expect(wrapper.vm.$validator.errors.count()).toBe(1);
+});
+


### PR DESCRIPTION
#### Overview

This PR aims to improve the way VeeValidate deals with `v-model` bound fields in custom components.

When setting up the field, the plugin will check if the [component customizes its v-model](https://vuejs.org/v2/guide/components-custom-events.html#Customizing-Component-v-model) behavior and use that info to improve the overall detection code. 

Which should eliminate many cases where `data-vv-validate-on` and `data-vv-value-path` is used on components authored by 3rd parties.

Related issues: #1324