### PR TITLE
Don't check if Event is a function - IE fix

### DIFF
--- a/src/core/field.js
+++ b/src/core/field.js
@@ -547,7 +547,7 @@ export default class Field {
       this.validator.validate(`#${this.targetOf}`);
     } : (...args) => {
       // if its a DOM event, resolve the value, otherwise use the first parameter as the value.
-      if (args.length === 0 || (isCallable(Event) && args[0] instanceof Event) || (args[0] && args[0].srcElement)) {
+      if (args.length === 0 || args[0] instanceof Event || (args[0] && args[0].srcElement)) {
         args[0] = this.value;
       }
 


### PR DESCRIPTION
Hi,
can we please remove check if Event is a function?
IE 11 implements Event as an object: `typeof Event => "object"`

By that implementation difference following `if` won't trigger, leaving
`args[0]` as an Event object, not its value. Therefore validation will be
fired against Event, not a value - and won't pass.

---
Could we please make that change or some other IE 11 compatible implementation?