### PR TITLE
docs: fix method signature and docs layout

### DIFF
--- a/docs/api/validator.md
+++ b/docs/api/validator.md
@@ -16,7 +16,7 @@ The validator offers an API to add new fields and trigger validations.
 
 |Name  | Return Type  |Description  |
 |---------|---------|---------|
-|attach(field: Field | FieldOptions) | `Field` | attaches a new field to the validator. |
+| attach(field: FieldOptions) | `Field` | attaches a new field to the validator. |
 | validate(descriptor?: String, value?: any, options?: Object) | `Promise<boolean>` | Validates the matching fields of the provided [descriptor](#field-descriptor). |
 | pause() | `void` | Disables validation. |
 | resume() | `void` | Enables validation. |


### PR DESCRIPTION
The table of the validator methods was broken and the [signature of the attach method](https://github.com/baianat/vee-validate/blob/c4b47d75e377bc91108dbeb292e40822895fafc6/src/core/validator.js#L173) was not correct.