### PR TITLE
Accepting of Negative numbers.

### DIFF
--- a/src/rules/numeric.js
+++ b/src/rules/numeric.js
@@ -1,9 +1,9 @@
 const validate = (value) => {
   if (Array.isArray(value)) {
-    return value.every(val => /^\-?[0-9]+$/.test(String(val)));
+    return value.every(val => /^-?[0-9]+$/.test(String(val)));
   }
 
-  return /^\-?[0-9]+$/.test(String(value));
+  return /^-?[0-9]+$/.test(String(value));
 };
 
 export {

--- a/src/rules/numeric.js
+++ b/src/rules/numeric.js
@@ -1,9 +1,9 @@
 const validate = (value) => {
   if (Array.isArray(value)) {
-    return value.every(val => /^[0-9]+$/.test(String(val)));
+    return value.every(val => /^\-?[0-9]+$/.test(String(val)));
   }
 
-  return /^[0-9]+$/.test(String(value));
+  return /^\-?[0-9]+$/.test(String(value));
 };
 
 export {

--- a/tests/unit/rules/numeric.js
+++ b/tests/unit/rules/numeric.js
@@ -13,8 +13,7 @@ const invalid = [
   true,
   false,
   {},
-  '+123',
-  '-123'
+  '+123'
 ];
 
 test('validates that the string only contains numeric characters', () => {

--- a/tests/unit/rules/numeric.js
+++ b/tests/unit/rules/numeric.js
@@ -2,7 +2,8 @@ import { validate } from '@/rules/numeric';
 
 const valid = [
   '1234567890',
-  123
+  123,
+  '-123'
 ];
 
 const invalid = [


### PR DESCRIPTION
## Description
This Pull Request allows us to validate negative numbers.

## Use case
Depending on the product, you might want to validate an input field like so "numeric|min_value:0|max_value:100".

## The Problem
Whenever you want to make sure the users are typing numbers between **0 and 100** but if she would like to put **-1** then it doesn't display the min_value error message. Instead, it displays the numeric error message **"The field may only contain numeric characters."** which is actually wrong.

## Solution
numeric should also recognize negative numbers.

## Testings:
```
/^-?[0-9]+$/.test(String("-122313.12")) // Decimals are, as before, not included
false

/^-?[0-9]+$/.test(String(-0))
true

/^-?[0-9]+$/.test(String(1))
true

/^-?[0-9]+$/.test(String(-1332))
true
```