### PR TITLE
fix #1447

### DIFF
--- a/src/core/field.js
+++ b/src/core/field.js
@@ -505,8 +505,8 @@ export default class Field {
       return (this.componentInstance.$options.model && this.componentInstance.$options.model.event) || 'input';
     }
 
-    if (this.model) {
-      return this.model.lazy ? 'change' : 'input';
+    if (this.model && this.model.lazy) {
+      return 'change';
     }
 
     if (isTextInput(this.el)) {


### PR DESCRIPTION
This PR addresses #1447 by correctly setting the `change` event for fields bound by a  `v-model` but not watchable due to them being in a `v-for` loop.