### PR TITLE
Fixed passing config in TypeScript code

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -164,6 +164,6 @@ export class ExtendOptions  {
 
 export const version: string;
 
-export const install: Vue.PluginFunction<never>
+export const install: Vue.PluginFunction<Configuration>
 
 export const directive: Vue.DirectiveOptions;


### PR DESCRIPTION
Current implementation does not allow to pass a global config when register the plugin in TypeScript. But with this fix it's possible to do like this:
```typescript
import VeeValidate, { Configuration } from 'vee-validate';

const veeValidateConfig = {
	classes: true
} as Configuration;

Vue.use(VeeValidate, veeValidateConfig);
```