### PR TITLE
feat: validation ctx

### DIFF
--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -521,7 +521,14 @@ export default class Validator {
       }
     }
 
-    let result = validator(value, this._convertParamArrayToObj(params, rule.name));
+    // Validation context
+    const ctx = {
+      validator: this,
+      vm: field.vm,
+      el: field.el
+    };
+
+    let result = validator(value, this._convertParamArrayToObj(params, rule.name), ctx);
 
     // If it is a promise.
     if (isCallable(result.then)) {

--- a/tests/unit/validator.js
+++ b/tests/unit/validator.js
@@ -1086,3 +1086,13 @@ test('maps rules params array to an object', async () => {
   expect((await v.verify('11.222', 'decimal:2')).valid).toBe(false);
   expect((await v.verify('11.222', { decimal: { decimals: 2 } })).valid).toBe(false);
 });
+
+test('provides access to the validation context as the third argument for rules', async () => {
+  const v = new Validator();
+  const rule = jest.fn(() => true);
+  v.extend('ctx', rule);
+
+  await v.verify('11', 'ctx');
+
+  expect(rule).toHaveBeenCalledWith('11', [], { validator: v, el: undefined, vm: undefined });
+});


### PR DESCRIPTION
Provides a third parameter to the rules validator functions, a validation context object.

This object holds information about the field, validator, and the Vue instance that the validation is occurring within. This allows the creation of very complex and impure/non-deterministic rules.

Mostly the design of the rules focused on the value and the rule config, this prevented creating rules that depend on different factors like the element or the component template. This gives the developer the ability to create such rules without resorting to extending/removing the rule consistently.

The validation context has the following properties:

```js
{
  el: 'the root? element being validated',
  validator: 'the validator instance',
  field: 'the field being validated',
  vm: 'the vue instance that the validator is running the validation in'
}
```

So in your rules you could do something like this:

```js
const confirms = (value, params, ctx) => {
  return value === ctx.vm.otherValue;
}
```

closes #1345