### PR TITLE
Add a guide to execute the vee-validate docs locally. A fix to #1590

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,21 @@ As you can see we have:
 - `locale` contains the localized messages files.
 - `tests` contains the test files for the project, it uses [jest](https://github.com/facebook/jest) for testing. it contains a similar folder structure as the `src` folder.
 
+### Contributing To The Docs
+
 If you want to contribute to the docs you can find it in the `docs` folder.
+
+Our docs require `./dist/vee-validate.esm` as dependency to run successfully in your local machine. You can generate this dependency by executing the following command from the root of the repository:
+
+```
+npm run build:esm
+```
+
+And then you can run vuepress by typing:
+
+```
+npm run docs:dev
+```
 
 ### Pull Requests
 


### PR DESCRIPTION
I found a little issue while trying to run vuepress, it would show an error from a missing file. Then I found out that I needed to run ``` npm run build:esm ``` the avoid this error. 

Well it might help other people in the future.

![screen shot 2018-09-16 at 6 26 19 pm](https://user-images.githubusercontent.com/1679333/45599403-e9240700-b9e2-11e8-8e41-25ec459d9802.png)
