### PR TITLE
Update docs: Remove integer rule from the Validation rules' page

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -20,7 +20,6 @@ VeeValidate comes with a bunch of validation rules out of the box and they are a
 - [ext](#ext)
 - [image](#image)
 - [included](#included)
-- [integer](#integer)
 - [ip](#ip)
 - [is](#is)
 - [is_not](#is-not)


### PR DESCRIPTION
I suppose that the integer was replaced by the [digits](https://baianat.github.io/vee-validate/guide/rules.html#digits) rule so I think it was no longer needed in index of [Validation rules'](https://baianat.github.io/vee-validate/guide/rules.html#validation-rules) page.

![screen shot 2018-09-16 at 7 12 55 pm](https://user-images.githubusercontent.com/1679333/45599502-8fbcd780-b9e4-11e8-8ac6-59f249c41a63.png)
