### PR TITLE
Fixed undefined 'decimale' in Romanian locale

### DIFF
--- a/locale/ro.js
+++ b/locale/ro.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `Câmpul ${field} este invalid.`,
   date_between: (field, [min, max]) => `Câmpul ${field} trebuie să fie între ${min} și ${max}.`,
   date_format: (field, [format]) => `Câmpul ${field} trebuie să fie în următorul format ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Câmpul ${field} trebuie să fie numberic și poate conține ${decimals === '*' ? '' : decimale} zecimale.`,
+  decimal: (field, [decimals = '*'] = []) => `Câmpul ${field} trebuie să fie numberic și poate conține ${decimals === '*' ? '' : decimals} zecimale.`,
   digits: (field, [length]) => `Câmpul ${field} trebuie să fie numeric și să conțină exact ${length} caractere.`,
   dimensions: (field, [width, height]) => `Câmpul ${field} trebuie să fie ${width} pixeli lungime și ${height} pixeli înălțime.`,
   email: (field) => `Câmpul ${field} trebuie să conțină un email valid.`,


### PR DESCRIPTION
The correct parameter to use is 'decimals'.