### PR TITLE
types definition : 'validate' name param is optional

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -147,7 +147,7 @@ export class Validator {
     localize(rootDictionary?: Object) :void;
     localize(language: string, dictionary?: Object) :void;
     setStrictMode(strictMode?: boolean): void;
-    validate(name: string, value?: any, scope?: string, silent?: boolean): Promise<any>;
+    validate(name?: string, value?: any, scope?: string, silent?: boolean): Promise<any>;
     validateAll(values?: Object, scope?: string, silent?: boolean): Promise<any>;
     validateScopes(silent?: boolean): Promise<any>;
     static create(validations: Object, options: any): Validator;


### PR DESCRIPTION
Got a small error using Typescript, the [`validate`](https://baianat.github.io/vee-validate/api/validator.html#api) method's `name` param is supposed to be optional