### PR TITLE
Fix ja messages

### DIFF
--- a/locale/ja.js
+++ b/locale/ja.js
@@ -1,6 +1,7 @@
 import { formatFileSize, isDefinedGlobally } from './utils';
 
 const messages = {
+  _default: (field) => `${field}の値が不正です`,
   after: (field, [target]) => `${field}は${target}の後でなければなりません`,
   alpha_dash: (field) => `${field}は英数字とハイフン、アンダースコアのみ使用できます`,
   alpha_num: (field) => `${field}は英数字のみ使用できます`,
@@ -20,6 +21,14 @@ const messages = {
   image: (field) => `${field}は有効な画像形式ではありません`,
   included: (field) => `${field}は有効な値ではありません`,
   ip: (field) => `${field}は有効なIPアドレスではありません`,
+  is: (field) => `${field}が一致しません`,
+  is_not: (field) => `${field}が一致しています`,
+  length: (field, [length, max]) => {
+    if (max) {
+      return `${field}は${length}文字以上${max}文字以下でなければなりません`;
+    }
+    return `${field}は${length}文字でなければなりません`;
+  },
   max: (field, [length]) => `${field}は${length}文字以内にしてください`,
   max_value: (field, [max]) => `${field}は${max}以下でなければなりません`,
   mimes: (field) => `${field}は有効なファイル形式ではありません`,
@@ -27,10 +36,10 @@ const messages = {
   min_value: (field, [min]) => `${field}は${min}以上でなければなりません`,
   excluded: (field) => `${field}は不正な値です`,
   numeric: (field) => `${field}は数字のみ使用できます`,
-  regex: (field) => `${field}が正しくありません`,
+  regex: (field) => `${field}のフォーマットが正しくありません`,
   required: (field) => `${field}は必須項目です`,
   size: (field, [size]) => `${field}は${formatFileSize(size)}以内でなければなりません`,
-  url: (field) => `${field}が正しくありません`
+  url: (field) => `${field}は有効なURLではありません`
 };
 
 const locale = {


### PR DESCRIPTION
Hi. Thanks for your great project. I've noticed that some ja messages are missed so I added.
The following image is just for confirmation.

<img width="464" alt="hello 2018-09-28 02-35-58" src="https://user-images.githubusercontent.com/546312/46163835-3c416800-c2c7-11e8-8242-91b0ad186da3.png">

Confirmed with the following Vue component.

```
<template>
  <div id="app">
    <div>
      <label>_default</label>
      <input name="_default" type="text" v-validate="'fail'">
      <p>{{ errors.first('_default') }}</p>
    </div>
    <div>
      <label>is</label>
      <input name="is" type="text" v-validate="{ is: 'HELLO' }">
      <p>{{ errors.first('is') }}</p>
    </div>
    <div>
      <label>is_not</label>
      <input name="is_not" type="text" v-validate="{ is_not: 'HELLO' }">
      <p>{{ errors.first('is_not') }}</p>
    </div>
    <div>
      <label>length</label>
      <input name="length" type="text" v-validate="'length:5'">
      <p>{{ errors.first('length') }}</p>
    </div>
    <div>
      <label>length (max)</label>
      <input name="length_max" type="text" v-validate="'length:5,10'">
      <p>{{ errors.first('length_max') }}</p>
    </div>
    <div>
      <label>regex</label>
      <input name="regex" type="text" v-validate="'regex:[0-9]'">
      <p>{{ errors.first('regex') }}</p>
    </div>
    <div>
      <label>url</label>
      <input name="url" type="text" v-validate="'url'">
      <p>{{ errors.first('url') }}</p>
    </div>
  </div>
</template>

<script>
export default {
  name: 'app',
}
</script>

<style>
div > div {
  border: 1px solid;
  margin: 0.5em;
  padding: 0.5em;
}
label {
  display: inline-block;
  width: 8em;
}
p {
  color: #fd4343;
}
</style>
```
