### PR TITLE
Verify Options

### DIFF
--- a/flow/validator.js
+++ b/flow/validator.js
@@ -47,3 +47,9 @@ declare type FieldOptions = {
   validity?: boolean, // if constrained validation API should be used (mdn)
   vm?: any // the vue instance that owns this field
 };
+
+declare type VerifyOptions = {
+  name?: string,
+  values?: MapObject,
+  bails?: boolean
+};

--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -126,6 +126,12 @@ export interface VerifyResult {
     errors: string[];
 }
 
+export interface VerifyOptions {
+    bails: boolean;
+    name: string;
+    values: { [x: string]: any };
+}
+
 export class Validator {
     errors: ErrorBag;
     fields: FieldBag;
@@ -155,7 +161,7 @@ export class Validator {
     validate(name: string, value?: any, scope?: string, silent?: boolean): Promise<any>;
     validateAll(values?: Object, scope?: string, silent?: boolean): Promise<any>;
     validateScopes(silent?: boolean): Promise<any>;
-    verify(value: any, rules: string|Object): Promise<VerifyResult>;
+    verify(value: any, rules: string|Object, options?: VerifyOptions): Promise<VerifyResult>;
     static create(validations: Object, options: any): Validator;
     static extend(name: string, validator: Object|Function, options?:ExtendOptions): void;
     static remove(name: string): void;


### PR DESCRIPTION
This introduces an options object as a third parameter that can be passed to the `validator.verify` method, which allows configuring field name, bailing behavior, and providing a value map to cross check for target dependent rules.

The options are:
```js
{
  bails: true,
  name: '{field}',
  values: {}
}
```

closes #1628 