### PR TITLE
Add paramNames to ExtendOptions definition

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -171,7 +171,8 @@ export class Validator {
 }
 
 export class ExtendOptions  {
-  hasTarget?: boolean
+  hasTarget?: boolean;
+  paramNames?: string[];
 }
 
 export const version: string;


### PR DESCRIPTION
__ 🔎 Overview__

Adding a custom validator, that uses names arguments, typescript returns an error for type checking.
This PR will just add the `paramNames` to the `ExtendOptions` so that typescript will no longer raise such an error

__ 🤓 Code snippets/examples (if applicable)__

```js
Validator.extend(rule, myValidator, {paramNames: ['rows', 'cols']});
Argument of type '{ paramNames: string[]; }' is not assignable to parameter of type 'ExtendOptions'
```

__✔ Issues affected__

Couldn't find any related issue.