### PR TITLE
Add import of ValidationObserver to docs

### DIFF
--- a/docs/guide/components/validation-observer.md
+++ b/docs/guide/components/validation-observer.md
@@ -86,6 +86,8 @@ export default {
   Using the same approach you can reset validation state for all providers using the public method `reset()`.
 :::
 
+[You can see observers in action here](/examples/validation-providers.md)
+
 ### Scopes And Groups
 
 The Validation Components API does not implement scopes and won't be, you can use the __ValidationObserver__ to group your fields without the complexties of the scopes API by using multiple observers and refs.

--- a/docs/guide/components/validation-observer.md
+++ b/docs/guide/components/validation-observer.md
@@ -16,6 +16,16 @@ Here is a small example, again with Vuetify components wrapped by the [Provider'
     <v-btn :disabled="invalid">Submit</v-btn>
   </form>
 </ValidationObserver>
+
+<script>
+import { ValidationObserver } from 'vee-validate';
+
+export default {
+  components: {
+    ValidationObserver
+  }
+};
+</script>
 ```
 
 ::: tip
@@ -75,8 +85,6 @@ export default {
 ::: tip
   Using the same approach you can reset validation state for all providers using the public method `reset()`.
 :::
-
-[You can see observers in action here](/examples/validation-providers.md)
 
 ### Scopes And Groups
 


### PR DESCRIPTION
🔎 __Overview__

The example for <ValidationProvider> shows the component being imported, but this page does not.

The "you can see observers in action here" link appears to be dead, and I can't find a page for it in the "Examples" section of the doc site, so I've removed it for now.
