### PR TITLE
Add errors and fields to the Vue typings

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -3,7 +3,7 @@
  */
 
 import Vue, { ComponentOptions } from 'vue';
-import { Validator, VeeValidateComponentOptions } from './vee-validate.d';
+import { ErrorBag, FieldFlagsBag, Validator, VeeValidateComponentOptions } from './vee-validate.d';
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
@@ -13,6 +13,23 @@ declare module 'vue/types/options' {
 
 declare module 'vue/types/vue' {
   interface Vue {
+    /**
+     * A `Validator` instance, injected via a mixin by VeeValidate.
+     *
+     * Note that this property is not available in the component if you are using `inject: false`.
+     */
     $validator: Validator;
+    /**
+     * An `ErrorBag` instance, injected via a mixin by VeeValidate.
+     *
+     * Note that this property is not available in the component if you are using `inject: false`.
+     */
+    errors: ErrorBag;
+    /**
+     * An object containing state flags for the validated fields, injected via a mixin by VeeValidate.
+     *
+     * Note that this property is not available in the component if you are using `inject: false`.
+     */
+    fields: FieldFlagsBag;
   }
 }


### PR DESCRIPTION
🔎 __Overview__

Feat: It allows to use `this.errors` and `this.fields` directly in TypeScript code, as they are injected via the mixin and documented (see https://baianat.github.io/vee-validate/api/mixin.html). The `$validator` was already exposed.

🤓 __Code snippets/examples (if applicable)__

Allows a method like:

```typescript
public isDirtyAndInError(name: string) {
  const field = this.$validator.fields.find({ name });
  if (field) {
    return field.flags.dirty && this.$validator.errors.has(name);
  }
  return false;
}
```

to be written as:

```typescript
public isDirtyAndInError(name: string) {
   return this.fields[name] && this.fields[name].dirty && this.errors.has(name);
}
```

✔ __Issues affected__

Fixes #1704

