### PR TITLE
Add mapFields helper to the typings

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -175,6 +175,12 @@ export class ExtendOptions  {
   paramNames?: string[];
 }
 
+/**
+ * `mapFields` helper, which is similar to Vuex's `mapGetters` and `mapActions`
+ * as it maps a field object to a computed property.
+ */
+export function mapFields(fields?: string[]|{[key: string]: string}): any;
+
 export const version: string;
 
 export const install: Vue.PluginFunction<Configuration>


### PR DESCRIPTION
🔎 __Overview__

It allows to use the `mapFields` helper into the `Component` decorator

🤓 __Code snippets/examples (if applicable)__

```typescript
@Component({
  computed: {
    form: mapFields(),
    ...mapFields(['login', 'password']),
    ...mapFields({
      name: 'login',
    }),
  },
})
export default class Login extends Vue {
```

✔ __Issues affected__

As discussed in #1705
Note that it could be more strictly typed, but I'm not sure about what the return type should be. It at elast allows to compile TS code that use `mapFields`.