### PR TITLE
 Add validation components to the typings

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -181,6 +181,20 @@ export class ExtendOptions  {
  */
 export function mapFields(fields?: string[]|{[key: string]: string}): any;
 
+/**
+ * The `ValidationObserver` is a convenient component that uses the `scoped slots` feature
+ * to communicate the current state of your inputs as a whole.
+ * Note that this component is renderless.
+ */
+export const ValidationObserver: Vue.Component;
+
+/**
+ * The `ValidationProvider` component is a regular component
+ * that wraps your inputs and provides validation state using `scoped slots`.
+ * Note that this component is renderless.
+ */
+export const ValidationProvider: Vue.Component;
+
 export const version: string;
 
 export const install: Vue.PluginFunction<Configuration>


### PR DESCRIPTION
🔎 __Overview__

It allows to use `validationProvider` and `ValidationObserver` in the `Component` decorator.

🤓 __Code snippets/examples (if applicable)__

```typescript
import { ValidationObserver, ValidationProvider } from 'vee-validate';

@Component({
  components: {
    ValidationObserver,
    ValidationProvider,
  },
})
export default class Login extends Vue {
```

✔ __Issues affected__

As discussed in #1705
