### PR TITLE
polish plurals

### DIFF
--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1,4 +1,7 @@
 import { formatFileSize, isDefinedGlobally } from './utils';
+import { polishPlurals } from 'polish-plurals';
+
+const characterLabel = polishPlurals.bind(null, 'znak', 'znaki', 'znaków');
 
 const messages = {
   _default: (field) => `Pole ${field} jest nieprawidłowe.`,
@@ -28,12 +31,12 @@ const messages = {
       return `Pole ${field} musi mieć długość od ${length} do ${max} znaków.`;
     }
 
-    return `Pole ${field} musi mieć długość ${length} znaków.`;
+    return `Pole ${field} musi mieć długość ${length} ${characterLabel(length)}.`;
   },
-  max: (field, [length]) => `Pole ${field} nie może być dłuższe niż ${length} znaków.`,
+  max: (field, [length]) => `Pole ${field} nie może być dłuższe niż ${length} ${characterLabel(length)}.`,
   max_value: (field, [max]) => `Pole ${field} musi mieć maksymalną wartość ${max}.`,
   mimes: (field) => `Plik ${field} musi posiadać poprawne rozszerzenie.`,
-  min: (field, [length]) => `Pole ${field} musi być długie na co najmniej ${length} znaków.`,
+  min: (field, [length]) => `Pole ${field} musi być długie na co najmniej ${length} ${characterLabel(length)}.`,
   min_value: (field, [min]) => `Pole ${field} musi mieć minimalną wartość ${min}.`,
   numeric: (field) => `Pole ${field} może zawierać tylko cyfry.`,
   regex: (field) => `Format pola ${field} jest nieodpowiedni.`,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jest": "^23.5.0",
     "lint-staged": "^8.0.4",
     "mkdirp": "^0.5.1",
+    "polish-plurals": "^1.1.0",
     "regenerator-runtime": "^0.12.1",
     "rollup": "^0.67.0",
     "rollup-plugin-buble": "^0.19.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8193,6 +8193,11 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+polish-plurals@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/polish-plurals/-/polish-plurals-1.1.0.tgz#c512cc06df8881c7f199dd12aba197552c3dada8"
+  integrity sha512-Sect6u4dScUC15pUZGhbfr7Q5o6CRAIpBj/KdkYf27EUa5Ls6+MkK5LXUH3PQL5aPAmFGnmJMXhdXzNLGc5V5A==
+
 portfinder@^1.0.13:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.17.tgz#a8a1691143e46c4735edefcf4fbcccedad26456a"


### PR DESCRIPTION
🔎 __Overview__

Ex (Locale):
> This PR changes the PL locale messages style because the current version has no variations for specific cases. It's a simple way to use nouns with numbers in Polish correctly.

🤓 __Code snippets/examples (if applicable)__

```js
  min: (field, [length]) => `Pole ${field} musi być długie na co najmniej ${length} ${characterLabel(length)}.` // if length = 3 / characterLabel = 'znaki', if length = 5 / characterLabel = 'znaków'
```

✔ __Issues affected__
none
