### PR TITLE
fix: make detach() scope parameter optional in validatorDecorator

### DIFF
--- a/src/core/validatorDecorator.js
+++ b/src/core/validatorDecorator.js
@@ -74,8 +74,8 @@ export default class ScopedValidator {
     return this._base.remove(ruleName);
   }
 
-  detach (...args) {
-    return this._base.detach(...args, this.id);
+  detach (name, scope) {
+    return this._base.detach(name, scope, this.id);
   }
 
   extend (...args) {

--- a/tests/unit/validatorDecorator.js
+++ b/tests/unit/validatorDecorator.js
@@ -66,6 +66,22 @@ test('decorates flag()', () => {
   expect(base.flag).toHaveBeenCalledWith('name', { valid: false }, 0);
 });
 
+test('decorates detach()', () => {
+  const base = new Validator();
+  const decorator = new Decorator(base, { _uid: 0 });
+
+  decorator.attach({ name: 'email1' });
+  decorator.attach({ name: 'email2' });
+  decorator.attach({ name: 'email3', scope: 'scope' });
+
+  decorator.detach('email1');
+  decorator.detach('email2', null);
+  decorator.detach('email3', 'scope');
+
+  expect(base.fields.items).toHaveLength(0);
+  expect(decorator.fields.items).toHaveLength(0);
+});
+
 test('calls extend()', () => {
   const vm = { _uid: 0 };
   const base = new Validator();


### PR DESCRIPTION
### 🔎 Overview
According to docs *scope* parameter in detach() method is optional, but in code it's required actually. 
If we want to remove field without scope, we must do this (which is not obvious): 
```js
validator.detach('field', null);
```

This pull-request makes *scope* parameter optional, so we also can do this:
```js
validator.detach('field');
```

## ✔ Related Issues
Possible related issue #782