### PR TITLE
feat: added persist directive (fixes #1799)

### DIFF
--- a/docs/api/directive.md
+++ b/docs/api/directive.md
@@ -65,6 +65,41 @@ export default {
 };
 </script>
 ```
+### persist
+
+You can use `.persist` modifier to keep the field (and its possible error(s)) in memory when the field is unmount/removed from the DOM (e.g. in a `v-if` block).
+If the field disappears from your component, it will stay accessible in the `fields` object.
+You'll be able to run a `validateAll()` with all your disappeared fields, very handy if you want to develop a multi-steps form with switching components.
+
+```vue
+<template>
+  <div>
+    <div v-if="displayField">
+      <input v-model="email" v-validate.persist="'required|email'" data-vv-validate-on="input" name="email" type="text">
+    </div>
+    <label><input type="checkbox" v-model="displayField"> Display the field</label>
+    <div>{{ errors.first('email') }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    email: '',
+    displayField: true
+  })
+};
+</script>
+```
+
+::: tip
+You can force it to disappear completely by changing the `persist` property in the field object:
+```js
+this.$validator.fields.find({name: 'email'}).persist = false;
+this.diplayField = false;
+// The field instance and its errors will also disappear from the memory in the next tick
+```
+:::
 
 ### continues
 

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -187,6 +187,10 @@ export const ValidationProvider = {
       type: Boolean,
       default: false
     },
+    persist: {
+      type: Boolean,
+      default: false
+    },
     bails: {
       type: Boolean,
       default: () => VeeValidate.config.fastExit

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -27,6 +27,7 @@ import {
 const DEFAULT_OPTIONS = {
   targetOf: null,
   immediate: false,
+  persist: false,
   scope: null,
   listen: true,
   name: null,
@@ -92,7 +93,7 @@ export default class Field {
     this._delay = !isNullOrUndefined(options.delay) ? options.delay : 0; // cache initial delay
     this.validity = options.validity;
     this.aria = options.aria;
-    this.flags = createFlags();
+    this.flags = options.flags || createFlags();
     this.vm = options.vm;
     this.componentInstance = options.component;
     this.ctorConfig = this.componentInstance ? getPath('$options.$_veeValidate', this.componentInstance) : undefined;
@@ -232,6 +233,7 @@ export default class Field {
   update (options: Object) {
     this.targetOf = options.targetOf || null;
     this.immediate = options.immediate || this.immediate || false;
+    this.persist = options.persist || this.persist || false;
 
     // update errors scope if the field scope was changed.
     if (!isNullOrUndefined(options.scope) && options.scope !== this.scope && isCallable(this.validator.update)) {

--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -42,6 +42,7 @@ export default class Resolver {
       delay: Resolver.resolveDelay(el, vnode, options),
       rules: Resolver.resolveRules(el, binding, vnode),
       immediate: !!binding.modifiers.initial || !!binding.modifiers.immediate,
+      persist: !!binding.modifiers.persist,
       validity: options.validity,
       aria: options.aria,
       initialValue: Resolver.resolveInitialValue(vnode)

--- a/tests/integration/components/Persist.vue
+++ b/tests/integration/components/Persist.vue
@@ -1,0 +1,19 @@
+<template>
+  <div v-if="displayFields">
+    <input type="text" name="field" v-validate="'required'">
+    <input type="text" name="field-immediate" v-validate.immediate="'required'">
+    <input type="text" name="field-persist" v-validate.persist="'required'">
+    <input type="text" name="field-persist-immediate" v-validate.persist.immediate="'required'">
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'persist-test',
+  data () {
+    return {
+      displayFields: true
+    };
+  }
+};
+</script>

--- a/tests/integration/persist.js
+++ b/tests/integration/persist.js
@@ -1,0 +1,57 @@
+import { shallow, createLocalVue } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import VeeValidate from '@/index';
+import TestComponent from './components/Persist';
+
+const Vue = createLocalVue();
+Vue.use(VeeValidate);
+
+test('persist fields should stay in the field list, as well as their errors', async () => {
+  const wrapper = shallow(TestComponent, { localVue: Vue });
+
+  await flushPromises();
+
+  // await new Promise(resolve => wrapper.vm.$nextTick(() => resolve()));
+  expect(wrapper.vm.errors.count()).toBe(2);
+  expect(Object.keys(wrapper.vm.fields).length).toBe(4);
+
+  wrapper.vm.displayFields = false; // We hide all the fields
+  await flushPromises();
+
+  expect(wrapper.vm.errors.count()).toBe(1); // Only one persist field is errored (because one is immediate)
+  expect(Object.keys(wrapper.vm.fields).length).toBe(2); // We expect the persist fields to be there
+
+  wrapper.vm.displayFields = true;
+  await flushPromises();
+
+  expect(wrapper.vm.errors.count()).toBe(2);
+  expect(Object.keys(wrapper.vm.fields).length).toBe(4); // The four fields are visible
+
+  expect(await wrapper.vm.$validator.validateAll()).toBe(false); // 4 required -> 4 errors
+
+  expect(wrapper.vm.errors.count()).toBe(4); // The .validateAll call has triggered 4 errors
+  expect(Object.keys(wrapper.vm.fields).length).toBe(4);
+
+  wrapper.vm.displayFields = false;
+  await flushPromises();
+
+  expect(wrapper.vm.errors.count()).toBe(2); // The two persist fields are still errored
+  expect(Object.keys(wrapper.vm.fields).length).toBe(2);
+
+  wrapper.vm.displayFields = true;
+  await flushPromises();
+
+  expect(wrapper.vm.errors.count()).toBe(3); // The two persist fields are still errored
+  expect(Object.keys(wrapper.vm.fields).length).toBe(4);
+
+  // The `valid` flag must stay the same as before
+  expect(wrapper.vm.fields['field-persist'].valid).toBe(false);
+
+  // One of the ways to remove the field is to set the persist prop to false
+  wrapper.vm.$validator.fields.find({ name: 'field-persist' }).persist = false;
+  wrapper.vm.displayFields = false;
+  await flushPromises();
+
+  expect(wrapper.vm.errors.count()).toBe(1);
+  expect(Object.keys(wrapper.vm.fields).length).toBe(1);
+});


### PR DESCRIPTION
🔎 __Overview__

The `.persist` directive (as discussed in #1799 between @HapLifeMan & @logaretm) consists in keeping the validation state (field instance & associated errors) when the field is removed from the DOM/component, allowing multi-views forms to use vee-validate properly, without missing errors from previous views.

I also implemented corresponding tests, & written docs about the feature.

🤓 __Code snippets/examples__

```vue
<template>
    <div>
        <div v-if="displayField">
            <input v-model="email" v-validate.persist="'required|email'" data-vv-validate-on="input" name="email" type="text">
        </div>
        <label><input type="checkbox" v-model="displayField"> Display the field</label>
        <div>{{ errors.first('email') }}</div>
    </div>
</template>

<script>
  export default {
    data: () => ({
      email: '',
      displayField: true,
    }),
  }
</script>
```
Noticeable change: The error stays even if the field is removed from the component.

✔ __Issues affected__

> fixes & satisfies #1799
