### PR TITLE
Fixed typo in conditional and looping guide

### DIFF
--- a/docs/guide/conditional-and-looping-inputs.md
+++ b/docs/guide/conditional-and-looping-inputs.md
@@ -21,7 +21,7 @@ The official example uses the following template:
 
 ## Handling v-if
 
-When attempting the validate those inputs, it would seem that vee-validate thinks they are the same one depending on who got rendered initially. This is due to Vue actually re-using the input, so to `vee-validate` and due to some limitation in the `directive` API, vee-validate doesn't know that the input got switched. So you need to help it a little bit by using `key` attribute on the inputs which forces Vue to render those elements independently.
+When attempting to validate those inputs, it would seem that vee-validate thinks they are the same one depending on who got rendered initially. This is due to Vue actually re-using the input, so to `vee-validate` and due to some limitation in the `directive` API, vee-validate doesn't know that the input got switched. So you need to help it a little bit by using `key` attribute on the inputs which forces Vue to render those elements independently.
 
 ```html
 <template v-if="loginType === 'username'">


### PR DESCRIPTION
Specifically in the `v-if` section.

🔎 __Overview__

This PR fixes a typo in the Conditional and Looping guide within the docs.

✔ __Issues affected__

No issue impacted
