### PR TITLE
feat: added `computesRequired` rule option and `required_if` rule

### DIFF
--- a/docs/guide/custom-rules.md
+++ b/docs/guide/custom-rules.md
@@ -131,6 +131,34 @@ These rules require at least one argument and the target field must have a match
 <input name="passwordConfirmation" ref="confirmation" type="password" placeholder="Confirm the password">
 ```
 
+## Require-like rules
+
+If you need to define a rule that declares a field as required under specific conditions, you will need to enable the `computesRequired` option. Because, by default, VeeValidate doesn't validate non require-like rules if the field has no value. The `computesRequired` will tell VeeValidate to run your rule even if the field has no value.
+
+In consequence, your rule **must** return an object with both `valid` and `data.required` boolean properties:
+```js
+validator.extend('my_custom_rule', (value, [otherValue]) => {
+  // do something and finally return an object like this one:
+  return {
+    valid: true, // or false
+    data: {
+      required: true // or false
+    }
+  };
+}, {
+  computesRequired: true
+});
+```
+
+Your rule also has to check for the requirement to be fulfilled.
+If `data.required` is set to false, the other field rules won't be executed if the field is empty.
+::: tip
+This option is best used when combined with `hasTarget`, to make a conditionnal requirement, based on other field values. Like the `require_if` rule.
+:::
+::: danger
+You cannot use this option if you want to write an async (promise-based) rule. You rule implementation has to be synchronous.
+:::
+
 ## Non-immediate Rules
 
 VeeValidate triggers initial validation regardless if you used the [immediate modifier](/api/directive.md#immediate) or not, the difference being if the immediate modifier is set, the errors and flags will be updated.

--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -34,6 +34,7 @@ VeeValidate comes with a bunch of validation rules out of the box and they are a
 - [numeric](#numeric)
 - [regex](#regex)
 - [required](#required)
+- [required_if](#required-if)
 - [size](#size)
 - [url](#url)
 
@@ -537,12 +538,39 @@ By default, the boolean value of `false` will pass validate. Setting invalidateF
 <span v-show="errors.has('required_field')" class="help is-danger">{{ errors.first('required_field') }}</span>
 
 ::: tip
-  The `required` rule is special, by default the validator skips the validation for non-required fields that have an empty value. If you wish to force validation for non-required fields, use the [`continues` modifier](/api/directive.md#continues).
+  The `required` &amp; `required_if` rules are special, by default the validator skips the validation for non-required fields that have an empty value. If you wish to force validation for non-required fields, use the [`continues` modifier](/api/directive.md#continues).
 :::
 
 ```html
 <input v-validate="'required'" data-vv-as="field" name="required_field" type="text">
 ```
+
+## required_if
+
+The field under validation must have a non-empty value **only if** the target field (first argument) is set to one of the specified values (other arguments).
+
+In the example below, the `required_if:country,US,FM` rule makes the `state` field required only if the `ref="country"` input is set to US or FM.
+If the target field value meets the requirement, empty values (empty strings, `undefined`, `null` and `false`) in the field under validation will trigger an error.
+
+<div>
+  <select ref="country" v-validate :class="{'input': true, 'is-danger': errors.has('required_field') }" name="select_country" >
+    <option value="US">United States of America</option>
+    <option value="FM">Federated States of Micronesia</option>
+    <option value="OTHER">Other country</option>
+  </select>
+  <input v-validate.immediate="'required_if:country,US,FM'" data-vv-as="state" :class="{'input': true, 'is-danger': errors.has('state_field') }" name="state_field" type="text" placeholder="State">
+</div>
+<span v-show="errors.has('state_field')" class="help is-danger">{{ errors.first('state_field') }}</span>
+
+```html
+<select ref="country" v-validate :class="{'input': true, 'is-danger': errors.has('required_field') }" name="select_country" >
+  <option value="US">United States</option>
+  <option value="OTHER">Other country</option>
+</select>
+<input v-validate.immediate="'required_if:country,US'" data-vv-as="state" :class="{'input': true, 'is-danger': errors.has('state_field') }" name="state_field" type="text" placeholder="State">
+<span v-show="errors.has('state_field')" class="help is-danger">{{ errors.first('state_field') }}</span>
+```
+
 
 ## size
 

--- a/locale/en.js
+++ b/locale/en.js
@@ -38,6 +38,7 @@ const messages = {
   numeric: (field) => `The ${field} field may only contain numeric characters.`,
   regex: (field) => `The ${field} field format is invalid.`,
   required: (field) => `The ${field} field is required.`,
+  required_if: (field, [target]) => `The ${field} field is required when the ${target} field has this value.`,
   size: (field, [size]) => `The ${field} size must be less than ${formatFileSize(size)}.`,
   url: (field) => `The ${field} field is not a valid URL.`
 };

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -38,6 +38,7 @@ const messages = {
   numeric: (field) => `Le champ ${field} ne peut contenir que des chiffres.`,
   regex: (field) => `Le champ ${field} est invalide.`,
   required: (field) => `Le champ ${field} est obligatoire.`,
+  required_if: (field, [target]) => `Le champ ${field} est obligatoire lorsque ${target} possède cette valeur.`,
   size: (field, [size]) => `Le champ ${field} doit avoir un poids inférieur à ${formatFileSize(size)}.`,
   url: (field) => `Le champ ${field} n'est pas une URL valide.`
 };

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -214,6 +214,7 @@ export const ValidationProvider = {
     initialized: false,
     initialValue: undefined,
     flags: createFlags(),
+    forceRequired: false,
     id: null
   }),
   methods: {
@@ -314,8 +315,9 @@ export const ValidationProvider = {
     },
     isRequired () {
       const rules = normalizeRules(this.rules);
+      const forceRequired = this.forceRequired;
 
-      return !!rules.required;
+      return !!rules.required || forceRequired;
     },
     classes () {
       const names = VeeValidate.config.classNames;

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -87,6 +87,7 @@ export default class Field {
     this.events = [];
     this.delay = 0;
     this.rules = {};
+    this.forceRequired = false;
     this._cacheId(options);
     this.classNames = assign({}, DEFAULT_OPTIONS.classNames);
     options = assign({}, DEFAULT_OPTIONS, options);
@@ -112,7 +113,7 @@ export default class Field {
   }
 
   get isRequired (): boolean {
-    return !!this.rules.required;
+    return !!this.rules.required || this.forceRequired;
   }
 
   get isDisabled (): boolean {

--- a/src/core/ruleContainer.js
+++ b/src/core/ruleContainer.js
@@ -21,6 +21,10 @@ export default class RuleContainer {
     return !!(RULES[name] && RULES[name].options.immediate);
   }
 
+  static isRequireRule (name) {
+    return !!(RULES[name] && RULES[name].options.computesRequired);
+  }
+
   static isTargetRule (name) {
     return !!(RULES[name] && RULES[name].options.hasTarget);
   }

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -31,6 +31,7 @@ import min_value from './min_value';
 import numeric from './numeric';
 import regex from './regex';
 import required from './required';
+import required_if from './required_if';
 import size from './size';
 import url from './url';
 
@@ -67,6 +68,7 @@ export {
   numeric,
   regex,
   required,
+  required_if,
   size,
   url
 };

--- a/src/rules/required_if.js
+++ b/src/rules/required_if.js
@@ -1,0 +1,40 @@
+import { isEmptyArray } from '../utils';
+
+const validate = (value, [otherFieldVal, ...possibleVals] = []) => {
+  let required = possibleVals.includes(String(otherFieldVal).trim());
+
+  if (!required) {
+    return {
+      valid: true,
+      data: {
+        required
+      }
+    };
+  }
+
+  let invalid = (isEmptyArray(value) || [false, null, undefined].includes(value));
+
+  invalid = invalid || !String(value).trim().length;
+
+  return {
+    valid: !invalid,
+    data: {
+      required
+    }
+  };
+};
+
+const options = {
+  hasTarget: true,
+  computesRequired: true
+};
+
+export {
+  validate,
+  options
+};
+
+export default {
+  validate,
+  options
+};

--- a/tests/integration/components/ComputesRequired.vue
+++ b/tests/integration/components/ComputesRequired.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <input type="text" name="f1" v-validate="'required_if:text,foo,baz|between:20,30'" id="f1" />
+    <input type="text" name="f1-continues" v-validate.continues="'required_if:text,foo,baz|between:20,30'" id="f1-continues" />
+    <input type="text" name="f2" ref="text" id="f2" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'computes-required'
+}
+</script>

--- a/tests/integration/computesRequired.js
+++ b/tests/integration/computesRequired.js
@@ -1,0 +1,59 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import VeeValidate from '@/index';
+import TestComponent from './components/ComputesRequired';
+
+const Vue = createLocalVue();
+const Validator = VeeValidate.Validator;
+
+Vue.use(VeeValidate);
+
+test('testing computesRequired rule (here required_if)', async () => {
+  Validator.localize('en');
+  await flushPromises();
+
+  const wrapper = mount(TestComponent, { localVue: Vue });
+
+  let input = wrapper.find('#f1');
+  let inputCont = wrapper.find('#f1-continues');
+  let ref = wrapper.find('#f2');
+
+  // We fill the ref element with some unrelevant value
+  ref.element.value = 'test';
+  ref.trigger('input');
+  await flushPromises();
+  await wrapper.vm.$validator.validateAll();
+  expect(wrapper.vm.$validator.errors.first('f1')).toBeFalsy();
+  // No errors because :
+  // - the ref element doesn't have "foo" or "baz" as value -> the input field is not required
+  // - input previously stated as "not required", not filled & not `.continues` -> the between rule is not executed
+
+  expect(wrapper.vm.$validator.errors.first('f1-continues')).toBe('The f1-continues field must be between 20 and 30.');
+  // The `.continues` input has the `between` rule error, it's good because `.continues` has to run through all the rules
+
+  // Now we fill the ref element with one of the two 'required_if' values
+  ref.element.value = 'baz';
+  ref.trigger('input');
+  await flushPromises();
+  expect(wrapper.vm.$validator.errors.first('f1')).toBe('The f1 field is required when the text field has this value.');
+  expect(wrapper.vm.$validator.errors.first('f1-continues')).toBe('The f1-continues field is required when the text field has this value.');
+
+  // We fill the input with numbers ; it should silent the require_if error, and let the between rule trigger
+  input.element.value = '10';
+  inputCont.element.value = '10';
+  input.trigger('input');
+  inputCont.trigger('input');
+  await flushPromises();
+
+  // The 'between' rule is the first (& only one) triggered error
+  expect(wrapper.vm.$validator.errors.first('f1')).toBe('The f1 field must be between 20 and 30.');
+  expect(wrapper.vm.$validator.errors.first('f1-continues')).toBe('The f1-continues field must be between 20 and 30.');
+
+  // We fill the input with correct values, and everything should be fine now
+  input.element.value = '25';
+  inputCont.element.value = '25';
+  input.trigger('input');
+  inputCont.trigger('input');
+  await flushPromises();
+  expect(wrapper.vm.$validator.errors.count()).toBe(0); // No errors left
+});

--- a/tests/unit/rules/required_if.js
+++ b/tests/unit/rules/required_if.js
@@ -1,0 +1,24 @@
+import { validate } from '@/rules/required_if';
+
+test('validates a conditional requirement', () => {
+  // foo is not part of [bar, baz] -> field is not required & valid
+  let test1 = validate('', ['foo', 'bar', 'baz']);
+  expect(test1).toMatchObject({
+    valid: true,
+    data: { required: false }
+  });
+
+  // foo is part of [bar, foo, baz] -> field is required & invalid
+  let test2 = validate('', ['foo', 'bar', 'foo', 'baz']);
+  expect(test2).toMatchObject({
+    valid: false,
+    data: { required: true }
+  });
+
+  // foo is part of [bar, foo, baz] -> field is required & valid
+  let test3 = validate('test', ['foo', 'bar', 'foo', 'baz']);
+  expect(test3).toMatchObject({
+    valid: true,
+    data: { required: true }
+  });
+});


### PR DESCRIPTION
### 🔎 __Overview__

This PR add the `computesRequired` rule option, which allows to implement required-like rules based on complex conditions. I've also implemented the `required_if` rule to demonstrate how to use the option for custom (or official) rules to come.

The `required_if` rule is based on the laravel validation rule (https://laravel.com/docs/5.7/validation#rule-required-if). It has been requested by other folks in issues (#1201, #41).

I also added en & fr locales associated to the `require_if` rule.

And the proper tests & docs. ;)

### 🤓 __Code snippets/examples__
Here is the `required_if` code:
```js
const validate = (value, [otherFieldVal, ...possibleVals] = []) => {
  let required = possibleVals.includes(String(otherFieldVal).trim());

  if (!required) {
    return {
      valid: true,
      data: {
        required
      }
    };
  }

  let invalid = (isEmptyArray(value) || [false, null, undefined].includes(value));

  invalid = invalid || !String(value).trim().length;

  return {
    valid: !invalid,
    data: {
      required
    }
  };
};

const options = {
  hasTarget: true,
  computesRequired: true
};

export {
  validate,
  options
};
```
Here is a use case example (taken from the doc I wrote):
```html
<div>
  <select ref="country" v-validate :class="{'input': true, 'is-danger': errors.has('required_field') }" name="select_country" >
    <option value="US">United States of America</option>
    <option value="FM">Federated States of Micronesia</option>
    <option value="OTHER">Other country</option>
  </select>
  <input v-validate.immediate="'required_if:country,US,FM'" data-vv-as="state" :class="{'input': true, 'is-danger': errors.has('state_field') }" name="state_field" type="text" placeholder="State">
</div>
<span v-show="errors.has('state_field')" class="help is-danger">{{ errors.first('state_field') }}</span>
```