### PR TITLE
feat: added computesRequired

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -178,9 +178,11 @@ export class Validator {
     static localize(language: string, dictionary?: Object): void;
 }
 
-export class ExtendOptions  {
+export class ExtendOptions {
   hasTarget?: boolean;
   paramNames?: string[];
+  computesRequired?: Boolean
+  initial?: Boolean
 }
 
 /**


### PR DESCRIPTION
added `computesRequired` to `Validator.extend` available options, which allows a rule to determine if the field is required after merging #1812