### PR TITLE
fix: double space character in decimal message

### DIFF
--- a/locale/ar.js
+++ b/locale/ar.js
@@ -26,7 +26,7 @@ const messages = {
   credit_card: (field) => `الحقل ${field} غير صحيح.`,
   date_between: (field, [min, max]) => `${field} يجب ان يكون ما بين ${min} و ${max}.`,
   date_format: (field, [format]) => `${field} يجب ان يكون على هيئة ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} يجب ان يكون قيمة رقمية وقد يحتوي على ${decimals === '*' ? '' : decimals} ارقام عشرية.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} يجب ان يكون قيمة رقمية وقد يحتوي على${decimals === '*' ? '' : ' ' + decimals} ارقام عشرية.`,
   digits: (field, [length]) => `${field} يجب ان تحتوي فقط على ارقام والا يزيد عددها عن ${length} رقم.`,
   dimensions: (field, [width, height]) => `${field} يجب ان تكون بمقاس ${width} بكسل في ${height} بكسل.`,
   email: (field) => `${field} يجب ان يكون بريدا اليكتروني صحيح.`,

--- a/locale/ca.js
+++ b/locale/ca.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field, [confirmedField]) => `El camp ${field} és invàlid.`,
   date_between: (field, [min, max]) => `El camp ${field} ha d'estar entre ${min} i ${max}.`,
   date_format: (field, [format]) => `El camp ${field} ha de tenir el format ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `El camp ${field} ha de ser numèric i contenir ${decimals === '*' ? '' : decimals} punts decimals.`,
+  decimal: (field, [decimals = '*'] = []) => `El camp ${field} ha de ser numèric i contenir${decimals === '*' ? '' : ' ' + decimals} punts decimals.`,
   digits: (field, [length]) => `El camp ${field} ha de ser numèric i contenir exactament ${length} dígits.`,
   dimensions: (field, [width, height]) => `El camp ${field} ha de ser de ${width} píxels per ${height} píxels.`,
   email: (field) => `El camp ${field} ha de ser un correu electrònic vàlid.`,

--- a/locale/cs.js
+++ b/locale/cs.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Pole ${field} není vyplněno správně.`,
   date_between: (field, [min, max]) => `Pole ${field} musí být mezi ${min} a ${max}.`,
   date_format: (field, [format]) => `Pole ${field} musí být ve formátu ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Pole ${field} musí být číslo a může obsahovat ${decimals === '*' ? '' : decimals} desetinných míst.`,
+  decimal: (field, [decimals = '*'] = []) => `Pole ${field} musí být číslo a může obsahovat${decimals === '*' ? '' : ' ' + decimals} desetinných míst.`,
   digits: (field, [length]) => `Pole ${field} musí být číslo a musí obshovat přesně ${length} číslic.`,
   dimensions: (field, [width, height]) => `${field} musí mít ${width} pixelů na ${height} pixelů.`,
   email: (field) => `Pole ${field} musí být validní email.`,

--- a/locale/da.js
+++ b/locale/da.js
@@ -12,7 +12,7 @@ const messages = {
   confirmed: (field, [confirmedField]) => `${field} skal matche ${confirmedField}.`,
   date_between: (field, [min, max]) => `${field} skal være mellem ${min} og ${max}.`,
   date_format: (field, [format]) => `${field} skal være i formatet: ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} skal være numerisk og må maksimalt indeholde ${decimals === '*' ? '' : decimals} decimaler.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} skal være numerisk og må maksimalt indeholde${decimals === '*' ? '' : ' ' + decimals} decimaler.`,
   digits: (field, [length]) => `${field} skal være et tal på ${length} cifre.`,
   dimensions: (field, [width, height]) => `${field} skal være ${width} pixels gange ${height} pixels.`,
   email: (field) => `${field} skal være en gyldig email.`,

--- a/locale/de.js
+++ b/locale/de.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} ist keine gültiger Wert für Kreditkarten.`,
   date_between: (field, [min, max]) => `${field} muss zwischen ${min} und ${max} liegen.`,
   date_format: (field, [format]) => `${field} muss das Format ${format} haben.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} muss numerisch sein und darf ${decimals === '*' ? '' : decimals} Dezimalpunkte enthalten.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} muss numerisch sein und darf${decimals === '*' ? '' : ' ' + decimals} Dezimalpunkte enthalten.`,
   digits: (field, [length]) => `${field} muss numerisch sein und exakt ${length} Ziffern enthalten.`,
   dimensions: (field, [width, height]) => `${field} muss ${width} x ${height} Bildpunkte groß sein.`,
   email: (field) => `${field} muss eine gültige E-Mail-Adresse sein.`,

--- a/locale/el.js
+++ b/locale/el.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} πρέπει να είναι έγκυρη πιστωτική κάρτα.`,
   date_between: (field, [min, max]) => `${field} πρέπει να είναι μεταξύ ${min} καί ${max}.`,
   date_format: (field, [format]) => `${field} πρέπει να είναι σε μορφή ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} πρέπει να είναι αριθμός και να περιέχει ${decimals === '*' ? '' : decimals} δεκαδικά ψηφία.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} πρέπει να είναι αριθμός και να περιέχει${decimals === '*' ? '' : ' ' + decimals} δεκαδικά ψηφία.`,
   digits: (field, [length]) => `${field} πρέπει να είναι αριθμός και να περιέχει ${length} ψηφία.`,
   dimensions: (field, [width, height]) => `${field} πρέπει να είναι ${width} pixels επί ${height} pixels.`,
   email: (field) => `${field} πρέπει να είναι έγκυρο email.`,

--- a/locale/es.js
+++ b/locale/es.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `El campo ${field} es inválido.`,
   date_between: (field, [min, max]) => `El campo ${field} debe estar entre ${min} y ${max}.`,
   date_format: (field, [format]) => `El campo ${field} debe tener un formato ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `El campo ${field} debe ser numérico y contener ${decimals === '*' ? '' : decimals} puntos decimales.`,
+  decimal: (field, [decimals = '*'] = []) => `El campo ${field} debe ser numérico y contener${decimals === '*' ? '' : ' ' + decimals} puntos decimales.`,
   digits: (field, [length]) => `El campo ${field} debe ser numérico y contener exactamente ${length} dígitos.`,
   dimensions: (field, [width, height]) => `El campo ${field} debe ser de ${width} píxeles por ${height} píxeles.`,
   email: (field) => `El campo ${field} debe ser un correo electrónico válido.`,

--- a/locale/fi.js
+++ b/locale/fi.js
@@ -10,7 +10,7 @@ const messages = {
   confirmed: (field, [confirmedField]) => `${field} ei vastannut ${confirmedField}.`,
   date_between: (field, [min, max]) => `${field} tulee olla ${min} ja ${max} väliltä.`,
   date_format: (field, [format]) => `${field} tulee olla muodossa ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} tulee olla numeerinen ja voi sisältää ${decimals === '*' ? '' : decimals} desimaalia.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} tulee olla numeerinen ja voi sisältää${decimals === '*' ? '' : ' ' + decimals} desimaalia.`,
   digits: (field, [length]) => `${field} tulee olla numeerinen ja tarkalleen ${length} merkkiä.`,
   dimensions: (field, [width, height]) => `${field} tulee olla ${width} pikseliä kertaa ${height} pikseliä.`,
   email: (field) => `${field} tulee olla kelvollinen sähköpostiosoite.`,

--- a/locale/he.js
+++ b/locale/he.js
@@ -11,7 +11,7 @@ const messages = {
   confirmed: (field) => `הערכים של ${field} חייבים להיות זהים.`,
   date_between: (field, [min, max]) => `השדה ${field} חייב להיות בין התאריכים ${min} ו- ${max}.`,
   date_format: (field, [format]) => `השדה ${field} חייב להיות בפורמט ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `השדה ${field} חייב להיות מספרי ולהכיל ${decimals === '*' ? '' : decimals} נקודות עשרוניות.`,
+  decimal: (field, [decimals = '*'] = []) => `השדה ${field} חייב להיות מספרי ולהכיל${decimals === '*' ? '' : ' ' + decimals} נקודות עשרוניות.`,
   digits: (field, [length]) => `השדה ${field} חייב להיות מספר ולהכיל ${length} ספרות בדיוק.`,
   dimensions: (field, [width, height]) => `השדה ${field} חייב להיות ${width} פיקסלים על ${height} פיקסלים.`,
   email: (field) => `השדה ${field} חייב להכיל כתובת אימייל תקינה.`,

--- a/locale/hr.js
+++ b/locale/hr.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} nije valjan.`,
   date_between: (field, [min, max]) => `${field} mora biti između ${min} i ${max}.`,
   date_format: (field, [format]) => `The ${field} mora biti u formatu ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} mora biti numerički i može sadržavati ${decimals === '*' ? '' : decimals} decimalne bodove.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} mora biti numerički i može sadržavati${decimals === '*' ? '' : ' ' + decimals} decimalne bodove.`,
   digits: (field, [length]) => `${field} mora biti numerički i točno sadrživati ${length} znamenke.`,
   dimensions: (field, [width, height]) => `${field} mora biti ${width} piksela za ${height} piksela.`,
   email: (field) => `${field} mora biti važeća e-pošta.`,

--- a/locale/hu.js
+++ b/locale/hu.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `A(z) ${field} nem érvényes.`,
   date_between: (field, [min, max]) => `A(z) ${field} ${min} és ${max} közötti dátum kell, hogy legyen.`,
   date_format: (field, [format]) => `A(z) ${field} nem egyezik az alábbi dátum formátummal ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `The ${field} must be numeric and may contain ${decimals === '*' ? '' : decimals} decimal points.`,
+  decimal: (field, [decimals = '*'] = []) => `The ${field} must be numeric and may contain${decimals === '*' ? '' : ' ' + decimals} decimal points.`,
   digits: (field, [length]) => `A(z) ${field} ${length} számjegyű kell, hogy legyen.`,
   dimensions: (field, [width, height]) => `A(z) ${field} felbontása ${width} és ${height} pixel között kell, hogy legyen.`,
   email: (field) => `A(z) ${field} nem érvényes email formátum.`,

--- a/locale/id.js
+++ b/locale/id.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} tidak sah.`,
   date_between: (field, [min, max]) => `${field} harus di antara ${min} dan ${max}.`,
   date_format: (field, [format]) => `${field} harus dalam format ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} harus berupa angka dan boleh mengandung ${decimals === '*' ? '' : decimals} titik desimal.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} harus berupa angka dan boleh mengandung${decimals === '*' ? '' : ' ' + decimals} titik desimal.`,
   digits: (field, [length]) => `${field} harus berupa ${length} digit angka.`,
   dimensions: (field, [width, height]) => `${field} harus berdimensi lebar ${width} pixel dan tinggi ${height} pixel.`,
   email: (field) => `${field} harus berupa alamat surel yang benar.`,

--- a/locale/ka.js
+++ b/locale/ka.js
@@ -11,7 +11,7 @@ const messages = {
   confirmed: (field, [confirmedField]) => `${field} არ ემთხვევა ${confirmedField}(ი)ს.`,
   date_between: (field, [min, max]) => `${field} უნდა უნდა იყოს ${min} და ${max}-ს შორის.`,
   date_format: (field, [format]) => `${field} უნდა იყოს ${format} ფორმატში.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} უნდა შეიცავდეს ციფრებსა და ${decimals === '*' ? '' : decimals} მთელ რიცხვებს.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} უნდა შეიცავდეს ციფრებსა და${decimals === '*' ? '' : ' ' + decimals} მთელ რიცხვებს.`,
   digits: (field, [length]) => `${field} უნდა შეიცავდეს ციფრებს და უნდა იყოს ზუსტად ${length}-ნიშნა.`,
   dimensions: (field, [width, height]) => `${field} უნდა იყოს ${width}x${height} ზომის (pixel).`,
   email: (field) => `${field}-ს უნდა ჰქონდეს ელ-ფოსტის სწორი ფორმატი.`,

--- a/locale/lt.js
+++ b/locale/lt.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Laukelis ${field} neteisingas.`,
   date_between: (field, [min, max]) => `Laukelio ${field} reikšmė turi būti tarp ${min} ir ${max}.`,
   date_format: (field, [format]) => `Laukelio ${field} formatas privalo būti toks - ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Laukelis ${field} turi būti skaitmuo su ${decimals === '*' ? '' : decimals} skaičium(-ias) po kablelio.`,
+  decimal: (field, [decimals = '*'] = []) => `Laukelis ${field} turi būti skaitmuo su${decimals === '*' ? '' : ' ' + decimals} skaičium(-ias) po kablelio.`,
   digits: (field, [length]) => `Lauklio ${field} reikšmė turi buti ${length} ženklų(-o) skaitmuo.`,
   dimensions: (field, [width, height]) => `${field} turi būti ${width} px x ${height} px.`,
   email: (field) => `Laukelis ${field} turi būti teisinga el. pašto adresas.`,

--- a/locale/nb_NO.js
+++ b/locale/nb_NO.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `${field}-feltet er ugyldig.`,
   date_between: (field, [min, max]) => `${field}-feltet må være imellom ${min} og ${max}.`,
   date_format: (field, [format]) => `${field}-feltet må være i følgende format: ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field}-feltet må være numerisk samt kan inneholde ${decimals === '*' ? '' : decimals} desimaler.`,
+  decimal: (field, [decimals = '*'] = []) => `${field}-feltet må være numerisk samt kan inneholde${decimals === '*' ? '' : ' ' + decimals} desimaler.`,
   digits: (field, [length]) => `${field}-feltet må være numerisk og inneholde nøyaktig ${length} siffer.`,
   dimensions: (field, [width, height]) => `${field}-feltet må være ${width} ganger ${height} piksler.`,
   email: (field) => `${field}-feltet må være en gyldig E-post adresse.`,

--- a/locale/nl.js
+++ b/locale/nl.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} is ongeldig.`,
   date_between: (field, [min, max]) => `${field} moet tussen ${min} en ${max} liggen.`,
   date_format: (field, [format]) => `${field} moet in het volgende formaat zijn: ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} moet een nummer zijn en mag ${decimals === '*' ? '' : decimals} decimalen bevatten.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} moet een nummer zijn en mag${decimals === '*' ? '' : ' ' + decimals} decimalen bevatten.`,
   digits: (field, [length]) => `${field} moet een nummer zijn en exact ${length} tekens bevatten.`,
   dimensions: (field, [width, height]) => `${field} moet ${width} pixels breed zijn en ${height} pixels hoog.`,
   email: (field) => `${field} moet een geldig e-mailadres zijn.`,

--- a/locale/nn_NO.js
+++ b/locale/nn_NO.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `${field}-feltet er ugyldig.`,
   date_between: (field, [min, max]) => `${field}-feltet må vere imellom ${min} og ${max}.`,
   date_format: (field, [format]) => `${field}-feltet må vere i følgende format: ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field}-feltet må vere numerisk, og kan innehalde ${decimals === '*' ? '' : decimals} desimaler.`,
+  decimal: (field, [decimals = '*'] = []) => `${field}-feltet må vere numerisk, og kan innehalde${decimals === '*' ? '' : ' ' + decimals} desimaler.`,
   digits: (field, [length]) => `${field}-feltet må vere numerisk og innehalde nøyaktig ${length} siffer.`,
   dimensions: (field, [width, height]) => `${field}-feltet må vere ${width} gonger ${height} piksler.`,
   email: (field) => `${field}-feltet må innehalde ein gyldig E-post adresse.`,

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -16,7 +16,7 @@ const messages = {
   credit_card: (field) => `Pole ${field} musi być poprawnym numerem karty kredytowej.`,
   date_between: (field, [min, max]) => `Pole ${field} musi zawierać się między ${min} a ${max}.`,
   date_format: (field, [format]) => `Pole ${field} musi pasować do formatu ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Pole ${field} musi być liczbą i może zawierać ${decimals === '*' ? '' : decimals} miejsca po przecinku.`,
+  decimal: (field, [decimals = '*'] = []) => `Pole ${field} musi być liczbą i może zawierać${decimals === '*' ? '' : ' ' + decimals} miejsca po przecinku.`,
   digits: (field, [length]) => `Pole ${field} musi być liczbą i dokładnie ${length} cyfr.`,
   dimensions: (field, [width, height]) => `Obraz ${field} musi być szeroki na ${width} pikseli i wysoki na ${height} pikseli.`,
   email: (field) => `Pole ${field} musi być poprawnym adresem email.`,

--- a/locale/pt_PT.js
+++ b/locale/pt_PT.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `O campo ${field} é inválido.`,
   date_between: (field, [min, max]) => `O campo ${field} deve estar entre ${min} e ${max}.`,
   date_format: (field, [format]) => `O campo ${field} deve estar no formato ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `O campo ${field} deve ser numérico e deve conter ${decimals === '*' ? '' : decimals} casas decimais.`,
+  decimal: (field, [decimals = '*'] = []) => `O campo ${field} deve ser numérico e deve conter${decimals === '*' ? '' : ' ' + decimals} casas decimais.`,
   digits: (field, [length]) => `O campo ${field} deve ser numérico e ter ${length} dígitos.`,
   dimensions: (field, [width, height]) => `O campo ${field} deve ter ${width} pixels de largura por ${height} pixels de altura.`,
   email: (field) => `O campo ${field} deve ser um email válido.`,

--- a/locale/ro.js
+++ b/locale/ro.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `Câmpul ${field} este invalid.`,
   date_between: (field, [min, max]) => `Câmpul ${field} trebuie să fie între ${min} și ${max}.`,
   date_format: (field, [format]) => `Câmpul ${field} trebuie să fie în următorul format ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Câmpul ${field} trebuie să fie numberic și poate conține ${decimals === '*' ? '' : decimals} zecimale.`,
+  decimal: (field, [decimals = '*'] = []) => `Câmpul ${field} trebuie să fie numberic și poate conține${decimals === '*' ? '' : ' ' + decimals} zecimale.`,
   digits: (field, [length]) => `Câmpul ${field} trebuie să fie numeric și să conțină exact ${length} caractere.`,
   dimensions: (field, [width, height]) => `Câmpul ${field} trebuie să fie ${width} pixeli lungime și ${height} pixeli înălțime.`,
   email: (field) => `Câmpul ${field} trebuie să conțină un email valid.`,

--- a/locale/ru.js
+++ b/locale/ru.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Поле ${field} должно быть действительным номером карты`,
   date_between: (field, [min, max]) => `Поле ${field} должно быть между ${min} и ${max}.`,
   date_format: (field, [format]) => `Поле ${field} должно быть в формате ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Поле ${field} должно быть числовым и может содержать ${decimals === '*' ? '' : decimals} десятичных числа.`,
+  decimal: (field, [decimals = '*'] = []) => `Поле ${field} должно быть числовым и может содержать${decimals === '*' ? '' : ' ' + decimals} десятичных числа.`,
   digits: (field, [length]) => `Поле ${field} должно быть числовым и точно содержать ${length} цифры.`,
   dimensions: (field, [width, height]) => `Поле ${field} должно быть ${width} пикселей на ${height} пикселей.`,
   email: (field) => `Поле ${field} должно быть действительным электронным адресом.`,

--- a/locale/sk.js
+++ b/locale/sk.js
@@ -12,7 +12,7 @@ const messages = {
   credit_card: (field) => `Položka ${field} je neplatná.`,
   date_between: (field, [min, max]) => `${field} musí byť medzi ${min} a ${max}.`,
   date_format: (field, [format]) => `${field} musí byť vo formáte ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Položka ${field} musí byť číselná a smie obsahovať ${decimals === '*' ? '' : decimals} desatinné miesta.`,
+  decimal: (field, [decimals = '*'] = []) => `Položka ${field} musí byť číselná a smie obsahovať${decimals === '*' ? '' : ' ' + decimals} desatinné miesta.`,
   digits: (field, [length]) => `Položka ${field} musí obsahovať ${length} ${length < 5 ? 'čísla' : 'čísiel'}.`,
   dimensions: (field, [width, height]) => `Položka ${field} musí mať ${width} x ${height} pixlov.`,
   email: (field) => `Položka ${field} musí obsahovať správnu emailovú adresu.`,

--- a/locale/sl.js
+++ b/locale/sl.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Polje ${field} ni veljavno.`,
   date_between: (field, [min, max]) => `Datum v polju ${field} mora biti med ${min} in ${max}.`,
   date_format: (field, [format]) => `Datum v polju ${field} mora biti sledečega formata: ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Polje ${field} mora biti numerično in lahko vsebuje ${decimals === '*' ? '' : decimals} decimalnih mest.`,
+  decimal: (field, [decimals = '*'] = []) => `Polje ${field} mora biti numerično in lahko vsebuje${decimals === '*' ? '' : ' ' + decimals} decimalnih mest.`,
   digits: (field, [length]) => `Vrednost polja ${field} mora biti numerična in vsebovati natančno ${length} številk.`,
   dimensions: (field, [width, height]) => `Slika ${field} mora biti široka ${width} slikovnih točk in visoka ${height} slikovnih točk.`,
   email: (field) => `Vrednost polja ${field} mora biti ustrezen e-naslov.`,

--- a/locale/sq.js
+++ b/locale/sq.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} nuk është valide.`,
   date_between: (field, [min, max]) => `${field} duhet të jetë në mes ${min} dhe ${max}.`,
   date_format: (field, [format]) => `${field} duhet të jetë në formatin ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} duhet të jetë numerike dhe të përmbaj ${decimals === '*' ? '' : decimals} presje dhjetore.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} duhet të jetë numerike dhe të përmbaj${decimals === '*' ? '' : ' ' + decimals} presje dhjetore.`,
   digits: (field, [length]) => `${field} duhet të jetë numerike dhe të përmbaj saktësisht ${length} shifra.`,
   dimensions: (field, [width, height]) => `${field} duhet të jetë ${width} piksela me ${height} piksela.`,
   email: (field) => `${field} duhet të jetë e-mail valid.`,

--- a/locale/sr.js
+++ b/locale/sr.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Поље ${field} није валидно.`,
   date_between: (field, [min, max]) => `Поље ${field} мора бити између ${min} и ${max}.`,
   date_format: (field, [format]) => `Поље ${field} мора бити у формату ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Поље ${field} мора бити број и може садржати ${decimals === '*' ? '' : decimals} децималних места.`,
+  decimal: (field, [decimals = '*'] = []) => `Поље ${field} мора бити број и може садржати${decimals === '*' ? '' : ' ' + decimals} децималних места.`,
   digits: (field, [length]) => `Поље ${field} мора бити број и садржати тачно ${length} цифара.`,
   dimensions: (field, [width, height]) => `Поље ${field} мора бити ${width} x ${height} пиксела.`,
   email: (field) => `Поље ${field} мора бити валидан имејл.`,

--- a/locale/sr_Latin.js
+++ b/locale/sr_Latin.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Polje ${field} nije validno.`,
   date_between: (field, [min, max]) => `Polje ${field} mora biti između ${min} i ${max}.`,
   date_format: (field, [format]) => `Polje ${field} mora biti u formatu ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Polje ${field} mora biti broj i može sadržati ${decimals === '*' ? '' : decimals} decimalnih mesta.`,
+  decimal: (field, [decimals = '*'] = []) => `Polje ${field} mora biti broj i može sadržati${decimals === '*' ? '' : ' ' + decimals} decimalnih mesta.`,
   digits: (field, [length]) => `Polje ${field} mora biti broj i sadržati tačno ${length} cifara.`,
   dimensions: (field, [width, height]) => `Polje ${field} mora biti ${width} x ${height} piksela.`,
   email: (field) => `Polje ${field} mora biti validan imejl.`,

--- a/locale/vi.js
+++ b/locale/vi.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Đã điền ${field} không chính xác.`,
   date_between: (field, [min, max]) => `${field} phải có giá trị nằm trong khoảng giữa  ${min} và ${max}.`,
   date_format: (field, [format]) => `${field} phải có giá trị dưới định dạng ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `${field} chỉ có thể chứa các kí tự số và dấu thập phân ${decimals === '*' ? '' : decimals}.`,
+  decimal: (field, [decimals = '*'] = []) => `${field} chỉ có thể chứa các kí tự số và dấu thập phân${decimals === '*' ? '' : ' ' + decimals}.`,
   digits: (field, [length]) => `Trường ${field} chỉ có thể chứa các kí tự số và bắt buộc phải có độ dài là ${length}.`,
   dimensions: (field, [width, height]) => `${field} phải có chiều rộng ${width} pixels và chiều cao ${height} pixels.`,
   email: (field) => `${field} phải là một địa chỉ email hợp lệ.`,

--- a/locale/zh_TW.js
+++ b/locale/zh_TW.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `${field} 的格式錯誤。`,
   date_between: (field, [min, max]) => `${field} 必須在 ${min} 和 ${max} 之間。`,
   date_format: (field, [format]) => `${field} 不符合 ${format} 的格式。`,
-  decimal: (field, [decimals = '*'] = []) => `${field} 必須是數字，而且能夠保留 ${decimals === '*' ? '' : decimals} 位小數。`,
+  decimal: (field, [decimals = '*'] = []) => `${field} 必須是數字，而且能夠保留${decimals === '*' ? '' : ' ' + decimals} 位小數。`,
   digits: (field, [length]) => `${field} 必須是 ${length} 位數字。`,
   dimensions: (field, [width, height]) => `${field} 圖片尺寸不正確。必須是 ${width} 像素到 ${height} 像素。`,
   email: (field) => `${field} 必須是有效的電子郵件地址。`,


### PR DESCRIPTION
🔎 __Overview__

(Fix)

Currently, if the decimal message is displayed with no decimals parameter, then we end up with a double space:

    The field must be numeric and may contain  decimal points.

