### PR TITLE
fix: disable aria and validity for components

### DIFF
--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -43,8 +43,8 @@ export default class Resolver {
       rules: Resolver.resolveRules(el, binding, vnode),
       immediate: !!binding.modifiers.initial || !!binding.modifiers.immediate,
       persist: !!binding.modifiers.persist,
-      validity: options.validity,
-      aria: options.aria,
+      validity: options.validity && !vnode.componentInstance,
+      aria: options.aria && !vnode.componentInstance,
       initialValue: Resolver.resolveInitialValue(vnode)
     };
   }


### PR DESCRIPTION
This disables aria attributes and validity API for custom components as they are not applicable to them anyways, they cause an issue for IE Edge when trying to resolve a component value upon manual validation.

closes #1854