### PR TITLE
feat: Allow multiple fields with the same name

### DIFF
--- a/src/core/errorBag.js
+++ b/src/core/errorBag.js
@@ -271,7 +271,7 @@ export default class ErrorBag {
   /**
    * Removes all error messages associated with a specific field.
    */
-  remove (field: string, scope: ?string, vmId: any) {
+  remove (field: string, scope: ?string, vmId: any, fieldId: ?string) {
     if (isNullOrUndefined(field)) {
       return;
     }
@@ -279,10 +279,11 @@ export default class ErrorBag {
     const selector = isNullOrUndefined(scope) ? String(field) : `${scope}.${field}`;
     const { isPrimary, isAlt } = this._makeCandidateFilters(selector);
     const matches = item => isPrimary(item) || isAlt(item);
+    const matchesId = item => (isNullOrUndefined(item.id) || isNullOrUndefined(fieldId) || item.id === fieldId);
     const shouldRemove = (item) => {
-      if (isNullOrUndefined(vmId)) return matches(item);
+      if (isNullOrUndefined(vmId)) return matches(item) && matchesId(item);
 
-      return matches(item) && item.vmId === vmId;
+      return matches(item) && item.vmId === vmId && matchesId(item);
     };
 
     for (let i = 0; i < this.items.length; ++i) {

--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -239,9 +239,9 @@ export default class Validator {
 
     // We destroy/remove the field & error instances if it's not a `persist` one
     if (!field.persist) {
-      field.destroy();
       this.errors.remove(field.name, field.scope, field.vmId);
       this.fields.remove(field);
+      field.destroy();
     }
   }
 
@@ -260,7 +260,7 @@ export default class Validator {
       this.fields.filter(matcher).forEach(field => {
         field.waitFor(null);
         field.reset(); // reset field flags.
-        this.errors.remove(field.name, field.scope, matcher && matcher.vmId);
+        this.errors.remove(field.name, field.scope, matcher && matcher.vmId, field.id);
       });
     });
   }
@@ -701,7 +701,7 @@ export default class Validator {
     this.errors.removeById(matchers.map(m => m.id));
     // remove by name and scope to remove any custom errors added.
     results.forEach(result => {
-      this.errors.remove(result.field, result.scope, vmId);
+      this.errors.remove(result.field, result.scope, vmId, (result != null && result.field != null ? result.field.id : null));
     });
     const allErrors = results.reduce((prev, curr) => {
       prev.push(...curr.errors);


### PR DESCRIPTION
This improves the handling of sites with multiple inputs containing the same name. 

When removing errors from the ErrorBag, the code will now use the field id (if provided) in addition to the field name.  This will allow forms to have multiple inputs with the same name tag.  

Even though it is possible to work around this with unique name tags for your inputs, this allows you to maintain default error messages that make sense.  

For example, we can now do this and have default error messages that say "Name is required" for each missing field (instead of Name0, Name1, Name2, Name3 is required):

```
<div v-for="(u, i) in users" :key="u.validationId">
  <input v-model="u.Name" v-validate="required" name="Name" /><br/>
  <span class="invalid">{{ errors.FirstById(''+o.validationId) }}</span>
</div>
```



closes #1091 
