### PR TITLE
Add an ip_or_fqdn validator

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -22,6 +22,7 @@ VeeValidate comes with a bunch of validation rules out of the box and they are a
 - [included](#included)
 - [integer](#integer)
 - [ip](#ip)
+- [ip_or_fqdn](#ip_or_fqdn)
 - [is](#is)
 - [is_not](#is-not)
 - [length](#length)
@@ -345,6 +346,17 @@ The field under validation must have a string that is a valid ipv4 value.
 
 ```html
 <input v-validate="'ip'" data-vv-as="ip" name="ip_field" type="text">
+```
+
+## ip_or_fqdn
+
+The field under validation must have a string that is a valid ipv4 value, a valid ipv6 value, or a valid fully-qualified domain name.
+
+<input v-validate="'ip_or_fqdn'" data-vv-as="host_address" :class="{'input': true, 'is-danger': errors.has('host_address_field') }" name="host_address_field" type="text" placeholder="Your Host Address">
+<span v-show="errors.has('host_address_field')" class="help is-danger">{{ errors.first('host_address_field') }}</span>
+
+```html
+<input v-validate="'ip'" data-vv-as="host_address" name="host_address_field" type="text">
 ```
 
 ## is

--- a/locale/en.js
+++ b/locale/en.js
@@ -23,6 +23,7 @@ const messages = {
   included: (field) => `The ${field} field must be a valid value.`,
   integer: (field) => `The ${field} field must be an integer.`,
   ip: (field) => `The ${field} field must be a valid ip address.`,
+  ip_or_fqdn: (field) => `The ${field} field must be a valid ip address or FQDN.`,
   length: (field, [length, max]) => {
     if (max) {
       return `The ${field} length must be between ${length} and ${max}.`;

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -20,6 +20,7 @@ import image from './image';
 import included from './included';
 import integer from './integer';
 import ip from './ip';
+import ip_or_fqdn from './ip_or_fqdn';
 import is from './is';
 import is_not from './is_not';
 import length from './length';
@@ -57,6 +58,7 @@ export {
   integer,
   length,
   ip,
+  ip_or_fqdn,
   is_not,
   is,
   max,

--- a/src/rules/ip_or_fqdn.js
+++ b/src/rules/ip_or_fqdn.js
@@ -1,6 +1,6 @@
 import isIP from 'validator/lib/isIP';
 import isFQDN from 'validator/lib/isFQDN';
-import { isNullOrUndefined } from '../core/utils';
+import { isNullOrUndefined } from '../utils';
 
 const validate = (value) => {
   if (isNullOrUndefined(value)) {

--- a/src/rules/ip_or_fqdn.js
+++ b/src/rules/ip_or_fqdn.js
@@ -11,7 +11,7 @@ const validate = (value) => {
     return value.every(val => (isIP(val, '') || isFQDN(val)));
   }
 
-  return isIP(value, '') || isFQDN(value));
+  return isIP(value, '') || isFQDN(value);
 };
 
 export {

--- a/src/rules/ip_or_fqdn.js
+++ b/src/rules/ip_or_fqdn.js
@@ -2,12 +2,12 @@ import isIP from 'validator/lib/isIP';
 import isFQDN from 'validator/lib/isFQDN';
 import { isNullOrUndefined } from '../core/utils';
 
-const validate = (value) {
+const validate = (value) => {
   if (isNullOrUndefined(value)) {
     value = '';
   }
 
-  if (Array.isArray(value)) => {
+  if (Array.isArray(value)) {
     return value.every(val => (isIP(val, '') || isFQDN(val)));
   }
 

--- a/src/rules/ip_or_fqdn.js
+++ b/src/rules/ip_or_fqdn.js
@@ -1,0 +1,23 @@
+import isIP from 'validator/lib/isIP';
+import isFQDN from 'validator/lib/isFQDN';
+import { isNullOrUndefined } from '../core/utils';
+
+const validate = (value) {
+  if (isNullOrUndefined(value)) {
+    value = '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(val => (isIP(val, '') || isFQDN(val)));
+  }
+
+  return isIP(value, '') || isFQDN(value));
+};
+
+export {
+  validate
+  };
+
+export default {
+  validate
+};

--- a/src/rules/ip_or_fqdn.js
+++ b/src/rules/ip_or_fqdn.js
@@ -7,7 +7,7 @@ const validate = (value) {
     value = '';
   }
 
-  if (Array.isArray(value)) {
+  if (Array.isArray(value)) => {
     return value.every(val => (isIP(val, '') || isFQDN(val)));
   }
 

--- a/tests/unit/rules/ip_or_fqdn.js
+++ b/tests/unit/rules/ip_or_fqdn.js
@@ -1,0 +1,72 @@
+import { validate } from '@/rules/ip_or_fqdn';
+
+test('validates that the string is a valid ipv4 address', () => {
+  // valid.
+  ['192.168.1.1', '255.255.255.255'].forEach(value => expect(validate(value)).toBe(true));
+  expect(validate(['192.168.1.1', '255.255.255.255'])).toBe(true);
+
+  // invalid
+  ['192.168.a.1', '255.255.255.256', '23.a.f.234'].forEach(value => expect(validate(value)).toBe(false));
+  expect(validate(['192.168.a.1', '255.255.255.256', '23.a.f.234'])).toBe(false);
+});
+
+test('validates that the string is a valid ipv6 address', () => {
+  // valid.
+  [
+    '::1',
+    '2001:db8:0000:1:1:1:1:1',
+    '::ffff:127.0.0.1'
+  ].forEach(value => expect(validate(value)).toBe(true));
+  expect(validate([
+    '::1',
+    '2001:db8:0000:1:1:1:1:1',
+    '::ffff:127.0.0.1'
+  ], { version: 6 })).toBe(true);
+
+  // invalid
+  [
+    '127.0.0.1',
+    '0.0.0.0',
+    '255.255.255.255',
+    '1.2.3.4',
+    '::ffff:287.0.0.1',
+  ].forEach(value => expect(validate(value)).toBe(false));
+  expect(validate([
+    '127.0.0.1',
+    '0.0.0.0',
+    '255.255.255.255',
+    '1.2.3.4',
+    '::ffff:287.0.0.1',
+  ])).toBe(false);
+});
+
+test('validates that the string is a valid fully qualified domain name', () => {
+  // valid.
+  [
+    'google.com',
+    'www.wikipedia.org',
+    'amazon.co.uk'
+  ].forEach(value => expect(validate(value)).toBe(true));
+  expect(validate([
+    'google.com',
+    'www.wikipedia.org',
+    'amazon.co.uk'
+  ])).toBe(true);
+
+  // invalid
+  [
+    'rubbish',
+    'abc 123',
+    '.com',
+  ].forEach(value => expect(validate(value)).toBe(false));
+  expect(validate([
+    'rubbish',
+    'abc 123',
+    '.com',
+  ])).toBe(false);
+});
+
+test('normalizes undefined or null to empty strings', () => {
+  expect(validate(null)).toBe(false);
+  expect(validate(undefined)).toBe(false);
+});

--- a/tests/unit/rules/ip_or_fqdn.js
+++ b/tests/unit/rules/ip_or_fqdn.js
@@ -1,53 +1,23 @@
 import { validate } from '@/rules/ip_or_fqdn';
 
-test('validates that the string is a valid ipv4 address', () => {
-  // valid.
-  ['192.168.1.1', '255.255.255.255'].forEach(value => expect(validate(value)).toBe(true));
-  expect(validate(['192.168.1.1', '255.255.255.255'])).toBe(true);
-
-  // invalid
-  ['192.168.a.1', '255.255.255.256', '23.a.f.234'].forEach(value => expect(validate(value)).toBe(false));
-  expect(validate(['192.168.a.1', '255.255.255.256', '23.a.f.234'])).toBe(false);
-});
-
-test('validates that the string is a valid ipv6 address', () => {
+test('validates that the string is a valid ipv4 or ipv6 address or a valid fqdn', () => {
   // valid.
   [
+    '192.168.1.1',
+    '255.255.255.255',
     '::1',
     '2001:db8:0000:1:1:1:1:1',
-    '::ffff:127.0.0.1'
-  ].forEach(value => expect(validate(value)).toBe(true));
-  expect(validate([
-    '::1',
-    '2001:db8:0000:1:1:1:1:1',
-    '::ffff:127.0.0.1'
-  ], { version: 6 })).toBe(true);
-
-  // invalid
-  [
-    '127.0.0.1',
-    '0.0.0.0',
-    '255.255.255.255',
-    '1.2.3.4',
-    '::ffff:287.0.0.1',
-  ].forEach(value => expect(validate(value)).toBe(false));
-  expect(validate([
-    '127.0.0.1',
-    '0.0.0.0',
-    '255.255.255.255',
-    '1.2.3.4',
-    '::ffff:287.0.0.1',
-  ])).toBe(false);
-});
-
-test('validates that the string is a valid fully qualified domain name', () => {
-  // valid.
-  [
+    '::ffff:127.0.0.1',
     'google.com',
     'www.wikipedia.org',
     'amazon.co.uk'
   ].forEach(value => expect(validate(value)).toBe(true));
   expect(validate([
+    '192.168.1.1',
+    '255.255.255.255',
+    '::1',
+    '2001:db8:0000:1:1:1:1:1',
+    '::ffff:127.0.0.1',
     'google.com',
     'www.wikipedia.org',
     'amazon.co.uk'
@@ -55,14 +25,26 @@ test('validates that the string is a valid fully qualified domain name', () => {
 
   // invalid
   [
+    '192.168.a.1',
+    '255.255.255.256',
+    '23.a.f.234',
+    '::ffff:287.0.0.1',
+    '1:2:3:4:5:6:7:8:9',
     'rubbish',
-    'abc 123',
-    '.com',
+    'abc 123.com',
+    'too..many.dots',
+    '.com'
   ].forEach(value => expect(validate(value)).toBe(false));
   expect(validate([
+    '192.168.a.1',
+    '255.255.255.256',
+    '23.a.f.234',
+    '::ffff:287.0.0.1',
+    '1:2:3:4:5:6:7:8:9',
     'rubbish',
-    'abc 123',
-    '.com',
+    'abc 123.com',
+    'too..many.dots',
+    '.com'
   ])).toBe(false);
 });
 


### PR DESCRIPTION
This adds a validator rule `ip_or_fqdn` which requires the field to be a valid IPv4 or IPv6 address, or a valid fully-qualified domain name.  Patch include documentation, tests, and an error message in the English locale.  I don't know any other languages well enough to write error messages for them.