### PR TITLE
fix: VerifyOptions TS properties should be optional closes #1845

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -127,9 +127,9 @@ export interface VerifyResult {
 }
 
 export interface VerifyOptions {
-    bails: boolean;
-    name: string;
-    values: { [x: string]: any };
+    bails?: boolean;
+    name?: string;
+    values?: { [x: string]: any };
 }
 
 export interface ValidationSlotScopeData {


### PR DESCRIPTION
This fixes the `VerifyOptions` for the `Validator.verify` method and marks its properties as optional instead of required.

closes #1845