### PR TITLE
Feat nested observers

### DIFF
--- a/docs/guide/components/validation-observer.md
+++ b/docs/guide/components/validation-observer.md
@@ -18,7 +18,7 @@ Here is a small example, again with Vuetify components wrapped by the [Provider'
 </ValidationObserver>
 ```
 
-::: tip
+:::tip
   ValidationObserver is a __renderless__ component, meaning it does not render anything of its own. It only renders its slot, as such you need to have __only one root element__ in your slot, if you use the `template` tag it might cause render errors.
 :::
 
@@ -131,6 +131,29 @@ this.$refs.obs2.validate();
 
 Simple and clean.
 
+### Nested Observers
+
+Building upon the previous example, observers can be nested to create nested forms for advanced use-cases. The outmost observer is able to trigger validation/resets on child obeservers and providers. Its state is also synced with the child observers and providers alike.
+
+```vue
+<ValidationObserver ref="op">
+  <ValidationObserver ref="oc" slot-scope="obsctx">
+    <div>
+      <ValidationProvider rules="required">
+        <div slot-scope="ctx">
+          <input type="text" v-model="value">
+          <span>{{ ctx.errors[0] }}</span>
+        </div>
+      </ValidationProvider>
+      <!-- This is synced with the state of all children providers/observers -->
+      <pre>
+        {{ obsctx }}
+      </pre>
+    </div>
+  </ValidationObserver>
+</ValidationObserver>
+```
+
 ## Reference
 
 Below is the reference of the ValidationObserver public API.
@@ -139,14 +162,14 @@ Below is the reference of the ValidationObserver public API.
 
 The validation observer does not accept any props.
 
-## Methods
+### Methods
 
 Those are the only methods meant for public usage, other methods that may exist on the ValidationObserver are strictly internal.
 
 |Method       | Args    | Return Value                  | Description                                                     |
 |-------------|:-------:|:-----------------------------:|-----------------------------------------------------------------|
-| validate    | `void`  | `Promise<boolean>`            | Validates all the child providers and also mutates their state. |
-| reset       | `void`  | `void`                        | Resets validation state for all child providers.                |
+| validate    | `void`  | `Promise<boolean>`            | Validates all the child providers/observers and also mutates their state. |
+| reset       | `void`  | `void`                        | Resets validation state for all child providers/observers.                |
 
 ### Events
 

--- a/docs/guide/components/validation-provider.md
+++ b/docs/guide/components/validation-provider.md
@@ -269,7 +269,7 @@ All the following props are optional.
 | bails     | `boolean` | `true`                | If true, the validation will stop on the first failing rule.                  |
 | debounce  | `number`  | `0`                   | Debounces the validation for the specified amount of milliseconds.           |
 
-## Methods
+### Methods
 
 Those are the only methods meant for public usage, other methods that may exist on the ValidationProvider are strictly internal.
 

--- a/src/components/observer.js
+++ b/src/components/observer.js
@@ -87,6 +87,16 @@ export const ValidationObserver = {
       this.$_veeObserver.subscribe(this, 'observer');
     }
   },
+  activated () {
+    if (this.$_veeObserver) {
+      this.$_veeObserver.subscribe(this, 'observer');
+    }
+  },
+  deactivated () {
+    if (this.$_veeObserver) {
+      this.$_veeObserver.unsubscribe(this, 'observer');
+    }
+  },
   beforeDestroy () {
     if (this.$_veeObserver) {
       this.$_veeObserver.unsubscribe(this, 'observer');

--- a/src/components/observer.js
+++ b/src/components/observer.js
@@ -29,10 +29,10 @@ export const ValidationObserver = {
     refs: {}
   }),
   methods: {
-    $subscribe (provider) {
+    subscribe (provider) {
       this.refs = Object.assign({}, this.refs, { [provider.vid]: provider });
     },
-    $unsubscribe ({ vid }) {
+    unsubscribe ({ vid }) {
       this.$delete(this.refs, vid);
     },
     validate () {

--- a/src/components/observer.js
+++ b/src/components/observer.js
@@ -1,5 +1,5 @@
 import { createRenderless } from '../utils/vnode';
-import { isCallable, values } from '../utils';
+import { isCallable, values, findIndex } from '../utils';
 
 const flagMergingStrategy = {
   pristine: 'every',
@@ -18,6 +18,8 @@ function mergeFlags (lhs, rhs, strategy) {
   return [lhs, rhs][stratName](f => f);
 }
 
+let OBSERVER_COUNTER = 0;
+
 export const ValidationObserver = {
   name: 'ValidationObserver',
   provide () {
@@ -25,25 +27,23 @@ export const ValidationObserver = {
       $_veeObserver: this
     };
   },
-  data: () => ({
-    refs: {}
-  }),
-  methods: {
-    subscribe (provider) {
-      this.refs = Object.assign({}, this.refs, { [provider.vid]: provider });
-    },
-    unsubscribe ({ vid }) {
-      this.$delete(this.refs, vid);
-    },
-    validate () {
-      return Promise.all(
-        values(this.refs).map(ref => ref.validate())
-      ).then(results => results.every(r => r.valid));
-    },
-    reset () {
-      return values(this.refs).forEach(ref => ref.reset());
+  inject: {
+    $_veeObserver: {
+      from: '$_veeObserver',
+      default () {
+        if (!this.$vnode.context.$_veeObserver) {
+          return null;
+        }
+
+        return this.$vnode.context.$_veeObserver;
+      }
     }
   },
+  data: () => ({
+    vid: OBSERVER_COUNTER++,
+    refs: {},
+    observers: [],
+  }),
   computed: {
     ctx () {
       const ctx = {
@@ -82,6 +82,16 @@ export const ValidationObserver = {
       }, ctx);
     }
   },
+  created () {
+    if (this.$_veeObserver) {
+      this.$_veeObserver.subscribe(this, 'observer');
+    }
+  },
+  beforeDestroy () {
+    if (this.$_veeObserver) {
+      this.$_veeObserver.unsubscribe(this, 'observer');
+    }
+  },
   render (h) {
     let slots = this.$scopedSlots.default;
     if (!isCallable(slots)) {
@@ -89,5 +99,35 @@ export const ValidationObserver = {
     }
 
     return createRenderless(h, slots(this.ctx));
+  },
+  methods: {
+    subscribe (subscriber, kind = 'provider') {
+      if (kind === 'observer') {
+        this.observers.push(subscriber);
+        return;
+      }
+
+      this.refs = Object.assign({}, this.refs, { [subscriber.vid]: subscriber });
+    },
+    unsubscribe ({ vid }, kind = 'provider') {
+      if (kind === 'provider') {
+        this.$delete(this.refs, vid);
+        return;
+      }
+
+      const idx = findIndex(this.observers, o => o.vid === vid);
+      if (idx !== -1) {
+        this.observers.splice(idx, 1);
+      }
+    },
+    validate () {
+      return Promise.all([
+        ...values(this.refs).map(ref => ref.validate().then(r => r.valid)),
+        ...this.observers.map(obs => obs.validate())
+      ]).then(results => results.every(r => r));
+    },
+    reset () {
+      return [...values(this.refs), ...this.observers].forEach(ref => ref.reset());
+    }
   }
 };

--- a/src/components/observer.js
+++ b/src/components/observer.js
@@ -40,7 +40,7 @@ export const ValidationObserver = {
     }
   },
   data: () => ({
-    vid: OBSERVER_COUNTER++,
+    vid: `obs_${OBSERVER_COUNTER++}`,
     refs: {},
     observers: [],
   }),
@@ -66,17 +66,23 @@ export const ValidationObserver = {
         reset: () => this.reset()
       };
 
-      return values(this.refs).reduce((acc, provider) => {
+      return [
+        ...values(this.refs),
+        ...this.observers,
+      ].reduce((acc, provider) => {
         Object.keys(flagMergingStrategy).forEach(flag => {
+          const flags = provider.flags || provider.ctx;
           if (!(flag in acc)) {
-            acc[flag] = provider.flags[flag];
+            acc[flag] = flags[flag];
             return;
           }
 
-          acc[flag] = mergeFlags(acc[flag], provider.flags[flag], flag);
+          acc[flag] = mergeFlags(acc[flag], flags[flag], flag);
         });
 
-        acc.errors[provider.vid] = provider.messages;
+        acc.errors[provider.vid] = provider.messages || values(provider.ctx.errors).reduce((errs, obsErrors) => {
+          return errs.concat(obsErrors);
+        }, []);
 
         return acc;
       }, ctx);

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -157,20 +157,20 @@ function updateRenderingContextRefs (ctx) {
 
   // vid was changed.
   if (id !== vid && ctx.$_veeObserver.refs[id] === ctx) {
-    ctx.$_veeObserver.$unsubscribe(ctx);
+    ctx.$_veeObserver.unsubscribe(ctx);
   }
 
-  ctx.$_veeObserver.$subscribe(ctx);
+  ctx.$_veeObserver.subscribe(ctx);
   ctx.id = vid;
 }
 
 function createObserver () {
   return {
     refs: {},
-    $subscribe (ctx) {
+    subscribe (ctx) {
       this.refs[ctx.vid] = ctx;
     },
-    $unsubscribe (ctx) {
+    unsubscribe (ctx) {
       delete this.refs[ctx.vid];
     }
   };
@@ -332,14 +332,14 @@ export const ValidationProvider = {
   },
   beforeDestroy () {
     // cleanup reference.
-    this.$_veeObserver.$unsubscribe(this);
+    this.$_veeObserver.unsubscribe(this);
   },
   activated () {
-    this.$_veeObserver.$subscribe(this);
+    this.$_veeObserver.subscribe(this);
     this.isDeactivated = false;
   },
   deactivated () {
-    this.$_veeObserver.$unsubscribe(this);
+    this.$_veeObserver.unsubscribe(this);
     this.isDeactivated = true;
   },
   methods: {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -413,18 +413,25 @@ export const uniqId = (): string => {
   return newId;
 };
 
+export const findIndex = (arrayLike: { length: number } | any[], predicate: (any) => boolean): number => {
+  const array = Array.isArray(arrayLike) ? arrayLike : toArray(arrayLike);
+  for (let i = 0; i < array.length; i++) {
+    if (predicate(array[i])) {
+      return i;
+    }
+  }
+
+  return -1;
+};
+
 /**
  * finds the first element that satisfies the predicate callback, polyfills array.find
  */
 export const find = (arrayLike: { length: number } | any[], predicate: (any) => boolean): any => {
   const array = Array.isArray(arrayLike) ? arrayLike : toArray(arrayLike);
-  for (let i = 0; i < array.length; i++) {
-    if (predicate(array[i])) {
-      return array[i];
-    }
-  }
+  const idx = findIndex(array, predicate);
 
-  return undefined;
+  return idx === -1 ? undefined : array[idx];
 };
 
 export const isBuiltInComponent = (vnode: Object): boolean => {


### PR DESCRIPTION
This PR allows observers to be nested under other observer, parent observers are able to present a state of the entire child observer/provider tree.

Parent observers are able to trigger `validate` and `reset` on child observers and providers.

closes #1879 