### PR TITLE
Correct the example VueI18n Integration

### DIFF
--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -156,6 +156,7 @@ import validationMessages from 'vee-validate/dist/locale/en';
 Vue.use(VueI18n);
 
 const i18n = new VueI18n();
+i18n.locale = "en"; // set a default locale (without it, it won't work)
 
 Vue.use(VeeValidate, {
    i18nRootKey: 'validations', // customize the root path for validation messages.


### PR DESCRIPTION
Currently the example won't work without the line:
159: i18n.locale = "en"; // set a default locale (without it, it won't work)

For description look here https://github.com/baianat/vee-validate/issues/1891
and/or here
https://stackoverflow.com/questions/55045730/vue-i18n-integration-by-vee-validate-not-working-as-described-in-the-documentati

🔎 __Overview__

Explain the premise for adding this PR and why is it important.

Ex (Feat):
> This PR {adds/fixes/improves} the {feature/bug/something}.

Ex (Locale):
> This PR changes the {locale} messages style because {reason}

🤓 __Code snippets/examples (if applicable)__

```js
// some code
```

✔ __Issues affected__

list of issues formatted like this:

> closes #{issue id}
