### PR TITLE
Feat interaction modes

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -17,6 +17,7 @@ const sidebars = {
     'flags',
     'classes-and-styling',
     'events',
+    'interaction',
     'conditional-and-looping-inputs',
     'ui-integrations'
   ],

--- a/docs/guide/components/validation-provider.md
+++ b/docs/guide/components/validation-provider.md
@@ -264,10 +264,10 @@ All the following props are optional.
 |-----------|-----------|-----------------------|------------------------------------------------------------------------------|
 | rules     | `string`  | `undefined`           | The validation rules.                                                        |
 | vid       | `string`  | auto increment number | Identifier used for target/cross-field based rules.                          |
-| immediate | `boolean` | `false`               | If the field should be validated immediately after render (initially).        |
-| events    | `string[]`| `['input']`           | Events that will trigger validation.                                         |
+| immediate | `boolean` | `false`               | If the field should be validated immediately after render (initially).       |
+| events    | `string[]`| `['input']`           | deprecated: check [interaction modes](../interaction.md)                      |
 | name      | `string`  | `undefined`           | A string that will be used to replace `{field}` in error messages and for [custom error messages](/guide/messages.md#field-specific-custom-messages). |
-| bails     | `boolean` | `true`                | If true, the validation will stop on the first failing rule.                  |
+| bails     | `boolean` | `true`                | If true, the validation will stop on the first failing rule.                 |
 | debounce  | `number`  | `0`                   | Debounces the validation for the specified amount of milliseconds.           |
 
 ### Methods

--- a/docs/guide/interaction.md
+++ b/docs/guide/interaction.md
@@ -1,0 +1,81 @@
+# Interaction Modes
+
+This feature is only implemented for [ValidationProvider components](./components/validation-provider.md).
+
+Borrowing from the idea of interaction modes formalized by [vue-simple-validator](http://simple-vue-validator.magictek.cn/#m_modes). Interaction modes are used by vee-validate to determine when a validation should trigger. It is used as a replacement for the `events` prop.
+
+VeeValidate comes with **4 interaction modes** out of the box:
+
+- `aggressive`: this is the default behavior and it validates whenever an `input` event is emitted.
+- `passive`: doesn't validate on any event, so you can only validate manually.
+- `lazy`: validates on `change` or `blur` depending on the input type.
+- `eager`: when the field **is valid** or has not yet been interacted with, it will validate on `change`. When the field becomes invalid due to the first validation, it will validate on `input` for as long the field is invalid. When the field is valid again, it will go back to validating on `change`. It is a mix between the `aggressive` and `lazy` modes.
+
+## Configuration
+
+You can set any of the validation providers mode to any of those modes using the `mode` prop.
+
+```vue
+<ValidationProvider rules="required|email" mode="eager">
+  <div slot-scope="{ errors }">
+    <input v-model="val">
+    <span>{{ errors[0] }}</span>
+  </div>
+</ValidationProvider>
+```
+
+You can configure the mode for all providers in the config when you are installing the plugin:
+
+```js
+Vue.use(VeeValidate, {
+  mode: 'eager'
+});
+```
+
+And you can set it dynamically after the plugin has been installed using `VeeValidate.setMode`.
+
+```js
+import VeeValidate from 'vee-validate';
+
+// set all future providers default mode to passive.
+// does not affect existing ones.
+VeeValidate.setMode('passive');
+```
+
+## Custom Modes
+
+You also have the ability to create custom modes that suit your needs. A mode is a function that recieves an object containing useful information about the field. It contains:
+
+- `errors`: list of error messages.
+- `flags`: the field flag object.
+- `value`: the last validated field value.
+- `failedRules`: a map object of the rules that had failed validation and their messages.
+
+The mode function should then return an object containing some (or none) of those properties:
+
+- `on`: array of event names that should trigger validation eg: `['input', 'change']`
+- `debounce`: number of the debounce time value for the validation.
+
+Modes can be passed directly to providers `mode` prop or applied globally using `VeeValidate.setMode`.
+
+### Example
+
+This exmaple impelments a custom version that behaves similar to the `eager` mode, except it applies a **debouce** value depending on each event type, an input event usually has high trigger frequenecy in text fields, so we debounce it to only validate after the user has finished typing.
+
+```js
+VeeValidate.setMode('betterEager', ({ errors }) => {
+   // become slightly aggressive if the field is invalid.
+  if (errors.length) {
+    return {
+      on: ['input'],
+      debounce: 350
+    };
+  }
+
+  // validate immediately after leaving the field.
+  return {
+    on: ['change'],
+    debounce: 0
+  };
+});
+```

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -298,9 +298,8 @@ export const ValidationProvider = {
       const make = isCallable(this.mode) ? this.mode : modes[this.mode];
       const { events } = make({
         errors: this.messages,
-        valid: this.isValid,
-        invalid: !this.isValid,
-        value: this.value
+        value: this.value,
+        flags: this.flags
       });
 
       return normalizeEvents(events).map(e => {

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -307,9 +307,9 @@ export const ValidationProvider = {
       });
     },
     normalizedEvents () {
-      const { events } = computeModeSetting(this);
+      const { on } = computeModeSetting(this);
 
-      return normalizeEvents(events || this.events).map(e => {
+      return normalizeEvents(on || this.events || []).map(e => {
         if (e === 'input') {
           return this._inputEventName;
         }

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -209,7 +209,9 @@ export const ValidationProvider = {
     },
     mode: {
       type: [String, Function],
-      default: getConfig().mode
+      default: () => {
+        return getConfig().mode;
+      }
     },
     events: {
       type: Array,

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -228,6 +228,7 @@ export const ValidationProvider = {
     events: {
       type: Array,
       validate: () => {
+        /* istanbul ignore next */
         if (process.env.NODE_ENV !== 'production') {
           warn('events prop and config will be deprecated in future version please use the interaction modes instead');
         }
@@ -348,6 +349,7 @@ export const ValidationProvider = {
 
     // Gracefully handle non-existent scoped slots.
     let slot = this.$scopedSlots.default;
+    /* istanbul ignore next */
     if (!isCallable(slot)) {
       if (process.env.NODE_ENV !== 'production') {
         warn('ValidationProvider expects a scoped slot. Did you forget to add "slot-scope" to your slot?');

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -309,7 +309,7 @@ export const ValidationProvider = {
     normalizedEvents () {
       const { events } = computeModeSetting(this);
 
-      return normalizeEvents(events).map(e => {
+      return normalizeEvents(events || this.events).map(e => {
         if (e === 'input') {
           return this._inputEventName;
         }

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ const DEFAULT_CONFIG = {
   fastExit: true,
   aria: true,
   validity: false,
+  mode: 'aggressive',
   useConstraintAttrs: true,
   i18n: null,
   i18nRootKey: 'validation'

--- a/src/modes.js
+++ b/src/modes.js
@@ -1,25 +1,25 @@
 const aggressive = () => ({
-  events: ['input']
+  on: ['input']
 });
 
 const lazy = () => ({
-  events: ['change']
+  on: ['change']
 });
 
 const eager = ({ errors }) => {
   if (errors.length) {
     return {
-      events: ['input']
+      on: ['input']
     };
   }
 
   return {
-    events: ['change']
+    on: ['change']
   };
 };
 
 const passive = () => ({
-  events: []
+  on: []
 });
 
 export const modes = {

--- a/src/modes.js
+++ b/src/modes.js
@@ -1,0 +1,30 @@
+const aggressive = () => ({
+  events: ['input']
+});
+
+const lazy = () => ({
+  events: ['change']
+});
+
+const eager = ({ errors }) => {
+  if (errors.length) {
+    return {
+      events: ['input']
+    };
+  }
+
+  return {
+    events: ['change']
+  };
+};
+
+const passive = () => ({
+  events: []
+});
+
+export const modes = {
+  aggressive,
+  eager,
+  passive,
+  lazy
+};

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,6 +8,7 @@ import I18nDictionary from './localization/i18n';
 import { detectPassiveSupport } from './utils/events';
 import { setConfig, getConfig } from './config';
 import { setValidator } from './state';
+import { modes } from './modes';
 
 // @flow
 
@@ -42,6 +43,19 @@ class VeeValidate {
 
   static configure (cfg) {
     setConfig(cfg);
+  }
+
+  static setMode (mode, implementation) {
+    setConfig({ mode });
+    if (!implementation) {
+      return;
+    }
+
+    if (!isCallable(implementation)) {
+      throw new Error('A mode implementation must be a function');
+    }
+
+    modes[mode] = implementation;
   }
 
   static use (plugin: (ctx: PluginContext, options?: any) => any, options?: any = {}) {

--- a/tests/unit/component.js
+++ b/tests/unit/component.js
@@ -221,7 +221,7 @@ describe('Validation Provider Component', () => {
     expect(error.text()).toBe('');
   });
 
-  test('validates on custom events', async () => {
+  test('uses interaction modes', async () => {
     const wrapper = mount({
       data: () => ({
         value: ''
@@ -234,7 +234,7 @@ describe('Validation Provider Component', () => {
       },
       template: `
         <div>
-          <ValidationProvider rules="required" events="blur">
+          <ValidationProvider rules="required" mode="lazy">
             <div slot-scope="{ errors }">
               <TextInput v-model="value"></TextInput>
               <span id="error">{{ errors[0] }}</span>
@@ -252,7 +252,7 @@ describe('Validation Provider Component', () => {
     await flushPromises();
     // did not validate.
     expect(error.text()).toBe('');
-    input.trigger('blur');
+    input.trigger('change');
     await flushPromises();
     expect(error.text()).toBe(DEFAULT_REQUIRED_MESSAGE);
   });


### PR DESCRIPTION
🔎 __Overview__

Checklist:
- [x] Implementation.
- [x] Docs.

This PR adds the ability to specify an interaction mode as formalized by [simple-vue-validator](http://simple-vue-validator.magictek.cn/#m_modes).

There are 4 modes implemented for you by default:

- aggressive: this is the default mode and it always validates on `input`.
- passive: doesn't validate on any event, so you can only validate manually.
- lazy: validate on `change`.
- eager: validates on `change` for the first time, then if the field is invalid it will validate on `input`. If the field turns valid again it will go back to validating on `change`. This was a popular request by many developers #1426.

You can customize the mode for each validation provider using the `mode` prop:

```vue
<ValidationProvider rules="required|email" mode="eager">
  <div slot-scope="{ errors }">
    <input v-model="val">
    <span>{{ errors[0] }}</span>
  </div>
</ValidationProvider>
```

The vee-validate plugin has a new method `setMode` which will be used to provide custom modes and changing the mode dynamically as needed.

```js
import VeeValidate from 'vee-validate';

// set all future providers default mode to passive.
// does not affect existing ones.
VeeValidate.setMode('passive');
```

An interaction mode in vee-validate is a function that receives a context similar to the slot-scope props which can be used to customize the behavior of the validation. The function should return an object containing:

- on: Array of event names as strings, those events will be used as triggers for validation.
- debounce: A number to control the validation trigger frequency.

Here is a small example:

```js
import VeeValidate from 'vee-validate';

VeeValidate.setMode('betterEager', ({ errors }) => {
   // Become slightly aggressive if the field is invalid.
  if (errors.length) {
    return {
      on: ['input'],
      debounce: 400
    };
  }

  // validate after 2 seconds of leaving the field 
  return {
    on: ['change'],
    debounce: 2000
  };
});
```

Currently, the mode receives an object with those properties:

- errors: List of error messages.
- flags: the field flag object.
- value: the last validated field value.

These properties may change in the future to make it more powerful. One thing is to make sure that the browser/components emit the configured events properly.

__This feature will deprecate the `events` config but it will remain with a deprecation warning for a couple of releases.__

✔ __Issues affected__

list of issues formatted like this:

closes #1426, closes #1488, closes #501
