### PR TITLE
fix: event value mismatch with model value for checkboxes  (fix #1900)

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -86,7 +86,7 @@ export function createCommonHandlers (ctx) {
   if (!onValidate || ctx.$veeDebounce !== ctx.debounce) {
     onValidate = debounce(
       () => {
-        const pendingPromise = ctx.validate();
+        const pendingPromise = ctx.validateSilent();
         // avoids race conditions between successive validations.
         ctx._pendingValidation = pendingPromise;
         pendingPromise.then(result => {

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -86,14 +86,16 @@ export function createCommonHandlers (ctx) {
   if (!onValidate || ctx.$veeDebounce !== ctx.debounce) {
     onValidate = debounce(
       () => {
-        const pendingPromise = ctx.validateSilent();
-        // avoids race conditions between successive validations.
-        ctx._pendingValidation = pendingPromise;
-        pendingPromise.then(result => {
-          if (pendingPromise === ctx._pendingValidation) {
-            ctx.applyResult(result);
-            ctx._pendingValidation = null;
-          }
+        ctx.$nextTick(() => {
+          const pendingPromise = ctx.validateSilent();
+          // avoids race conditions between successive validations.
+          ctx._pendingValidation = pendingPromise;
+          pendingPromise.then(result => {
+            if (pendingPromise === ctx._pendingValidation) {
+              ctx.applyResult(result);
+              ctx._pendingValidation = null;
+            }
+          });
         });
       },
       ctx.debounce


### PR DESCRIPTION
This PR forces validation triggered by events to wait until the nextTick, this allows validation providers to validate checkboxes values after they've been stabilized.

closes #1900
