### PR TITLE
docs: updated the usage of vid for cross-field validation with providers

### DIFF
--- a/docs/guide/components/validation-provider.md
+++ b/docs/guide/components/validation-provider.md
@@ -153,7 +153,7 @@ Like radio inputs and (sometimes) checkboxes, some inputs behave as a single inp
 </ValidationProvider>
 ```
 
-### Confirmed/Target based Validation
+### Cross-Field Validation
 
 When using the directive, the `confirmed` rule targets the other field that has a corresponding `ref`. Using the ValidationProvider is slightly different; it looks for a ValidationProvider component that has a matching `vid` prop. The `vid` can be either a number or a string.
 

--- a/docs/guide/custom-rules.md
+++ b/docs/guide/custom-rules.md
@@ -108,7 +108,7 @@ The order is what controls the param names in that case. The validator will use 
 Locale methods will still recieve the array of args, it will not convert it to an object at the time being due to the possible breaking changes in locale files.
 :::
 
-## Target Dependant Rules
+## Cross-Field Rules
 
 Sometimes your rules may need to compare the field value against another field value, some built in rules like `confirmed`, `before` and `after` need a target field to compare against.
 
@@ -130,6 +130,8 @@ These rules require at least one argument and the target field must have a match
 <input v-validate="'confirmed:confirmation'" name="password" type="password" >
 <input name="passwordConfirmation" ref="confirmation" type="password" placeholder="Confirm the password">
 ```
+
+For [validation providers](./components/validation-provider.md) the target field must have a `vid` prop set instead of the `ref`.
 
 ## Require-like rules
 

--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -53,7 +53,7 @@ The field under validation must have a valid date and is after the date value in
 <input name="after_field_target" ref="afterTarget" :class="{'input': true, 'is-danger': errors.has('after_field') }" type="text" placeholder="DD/MM/YYYY">
 
 ::: tip
-  Target based rules like `after`, `before`, and `confirmed` can target custom components as well as native inputs, but the target field must have a `ref` attribute set and the confirmed parameter must be the same ref value.
+  Target based rules like `after`, `before`, and `confirmed` can target custom components as well as native inputs, but the target field must have a `ref` attribute set and the confirmed parameter must be the same ref value. For [validation providers](./components/validation-provider.md) the target field must have a `vid` prop set instead of the `ref`.
 :::
 
 ```html
@@ -122,7 +122,7 @@ The field under validation must have a valid date and is before the date value i
 <input name="before_field_target" ref="beforeTarget" :class="{'input': true, 'is-danger': errors.has('alpha_field') }" type="text" placeholder="DD/MM/YYYY">
 
 ::: tip
-  Target based rules like `after`, `before`, and `confirmed` can target custom components as well as native inputs, but the target field must have a `ref` attribute set and the confirmed parameter must be the same ref value.
+  Target based rules like `after`, `before`, and `confirmed` can target custom components as well as native inputs, but the target field must have a `ref` attribute set and the confirmed parameter must be the same ref value. For [validation providers](./components/validation-provider.md) the target field must have a `vid` prop set instead of the `ref`.
 :::
 
 ```html
@@ -162,7 +162,7 @@ The field under validation must have the same value as the confirmation field.
 <span v-show="errors.has('pw_confirm')" class="help is-danger">{{ errors.first('pw_confirm') }}</span>
 
 ::: tip
-  Target based rules like `after`, `before`, and `confirmed` can target custom components as well as native inputs, but the target field must have a `ref` attribute set and the confirmed parameter must be the same ref value.
+  Target based rules like `after`, `before`, and `confirmed` can target custom components as well as native inputs, but the target field must have a `ref` attribute set and the confirmed parameter must be the same ref value. For [validation providers](./components/validation-provider.md) the target field must have a `vid` prop set instead of the `ref`.
 :::
 
 ```html


### PR DESCRIPTION
Enhanced some notes on cross-field validation and the locating methods used by the directive or the providers.