### PR TITLE
Feat cross field validation behavior

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -268,8 +268,10 @@ export const ValidationProvider = {
         const watcherName = `$__${depName}`;
         if (!isCallable(this[watcherName])) {
           this[watcherName] = providers[depName].$watch('value', () => {
-            this._needsValidation = true;
-            this.validate();
+            if (this.flags.validated) {
+              this._needsValidation = true;
+              this.validate();
+            }
           });
         }
 

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -579,7 +579,10 @@ export default class Field {
 
     const token = { cancelled: false };
     const fn = this.targetOf ? () => {
-      this.validator.validate(`#${this.targetOf}`);
+      const target = this.validator._resolveField(`#${this.targetOf}`);
+      if (target && target.flags.validated) {
+        this.validator.validate(`#${this.targetOf}`);
+      }
     } : (...args) => {
       // if its a DOM event, resolve the value, otherwise use the first parameter as the value.
       if (args.length === 0 || isEvent(args[0])) {

--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -110,7 +110,8 @@ export default class Resolver {
       $validator: vm.$validator ? {
         errors: vm.$validator.errors,
         validate: vm.$validator.validate.bind(vm.$validator),
-        update: vm.$validator.update.bind(vm.$validator)
+        update: vm.$validator.update.bind(vm.$validator),
+        _resolveField: vm.$validator._base._resolveField.bind(vm.$validator)
       } : null
     };
   }

--- a/tests/unit/component.js
+++ b/tests/unit/component.js
@@ -281,18 +281,24 @@ describe('Validation Provider Component', () => {
     }, { localVue: Vue });
 
     const error = wrapper.find('#err1');
+    const inputs = wrapper.findAll('input');
 
     expect(error.text()).toBeFalsy();
-    wrapper.setData({
-      password: '',
-      confirmation: 'val'
-    });
+    inputs.at(0).element.value = 'val';
+    inputs.at(0).trigger('input');
     await flushPromises();
+    // the password input hasn't changed yet.
+    expect(error.text()).toBeFalsy();
+    inputs.at(1).element.value = '12';
+    inputs.at(1).trigger('input');
+    await flushPromises();
+    // the password input was interacted with and should be validated.
     expect(error.text()).toBeTruthy();
-    wrapper.setData({
-      password: 'val'
-    });
+
+    inputs.at(1).element.value = 'val';
+    inputs.at(1).trigger('input');
     await flushPromises();
+    // the password input now matches the confirmation.
     expect(error.text()).toBeFalsy();
   });
 


### PR DESCRIPTION
This PR forces the validation provider and the directive to not validate the cross-field targets until they have been interacted with or if validation was triggered manually at least once.

This solves the "aggressive" behavior when the user has only interacted with one of the two confirmed inputs for the first time.

closes #1902, closes #1869, closes #1765
