### PR TITLE
fix: handle embedded rules options imported from minimal bundle

### DIFF
--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -135,10 +135,13 @@ export default class Validator {
    */
   static extend (name: string, validator: Rule | Object, options?: ExtendOptions = {}) {
     Validator._guardExtend(name, validator);
+    // rules imported from the minimal bundle
+    // will have the options embedded in them
+    const mergedOpts = validator.options || {};
     Validator._merge(name, {
       validator,
-      paramNames: options && options.paramNames,
-      options: assign({}, { hasTarget: false, immediate: true }, options || {})
+      paramNames: (options && options.paramNames) || validator.paramNames,
+      options: assign({ hasTarget: false, immediate: true }, mergedOpts, options || {})
     });
   }
 


### PR DESCRIPTION
This PR fixes a long-standing issue where rules imported from the `dist/rules.esm` would not behave the same due to them having the rules options embedded in them. This causes the validator to not properly set the target fields nor correctly validate date values.


closes #1866, closes #1732