### PR TITLE
fix(perf): cap the rules watcher frequency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
             "always"
         ],
         "comma-dangle": 0,
+        "no-console": "error",
         "space-unary-ops": 0,
         "import/no-extraneous-dependencies": 0,
         "no-new": 0,

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -4,7 +4,7 @@ import { modes } from '../modes';
 import Validator from '../core/validator';
 import RuleContainer from '../core/ruleContainer';
 import { normalizeEvents, isEvent } from '../utils/events';
-import { createFlags, normalizeRules, warn, isCallable, debounce, isNullOrUndefined, assign } from '../utils';
+import { createFlags, normalizeRules, warn, isCallable, debounce, isNullOrUndefined, assign, isEqual } from '../utils';
 import { findModel, extractVNodes, addVNodeListener, getInputEventName } from '../utils/vnode';
 
 let $validator = null;
@@ -272,8 +272,8 @@ export const ValidationProvider = {
   watch: {
     rules: {
       deep: true,
-      handler () {
-        this._needsValidation = true;
+      handler (val, oldVal) {
+        this._needsValidation = !isEqual(val, oldVal);
       }
     }
   },


### PR DESCRIPTION
This PR changes how the providers `rules` watcher is implemented by only triggering validation only when the old rules value is different than the current one.

This didn't work properly with object syntax for rules and using the `observers` slot scope, which caused infinite render loop due to the rules object being having different reference each time a re-render happens.

This is similar to the directive's `update` loop having infinite loop due to the object reference not being the same which is the nature of inline values in Vue in general.

This is fixed by only allowing the component to re-validate only if the new rules object have different configuration than the old one.

this also should improve the performance slightly in other cases.

closes #1920