### PR TITLE
feat: added ts typings for validation provider and observer components

### DIFF
--- a/docs/guide/components/validation-provider.md
+++ b/docs/guide/components/validation-provider.md
@@ -289,6 +289,54 @@ Ideally you would pass the props you need to either the `ValidationProvider` or 
 
 Using either of these approaches is at your preference.
 
+## Adding Errors Manually
+
+You may want to add manual errors to a field, such cases like pre-filling initially due to a server response, or an async request. You can do this using `refs` and the `applyResult` method.
+
+```vue
+<template>
+  <div id="app">
+    <ValidationProvider ref="provider" rules="required">
+      <div slot-scope="{ errors }">
+        <input v-model="model" type="text">
+        <div v-if="errors" v-text="errors[0]"></div>
+      </div>
+    </ValidationProvider>
+  </div>
+</template>
+
+<script>
+import { ValidationProvider } from "vee-validate";
+
+export default {
+  components: {
+    ValidationProvider
+  },
+  mounted() {
+    // all those properties are required.
+    this.$refs.provider.applyResult({
+      errors: ["this is a backend error"], // array of string errors
+      valid: false, // boolean state
+      failedRules: {} // should be empty since this is a manual error.
+    });
+  }
+};
+</script>
+```
+
+::: tip
+If you are using TypeScript you may face issues with `$refs` not giving you the correct typings, you can solve that by casting the ref to a `ValidationProvider`.
+
+```ts
+(this.$refs.provider as ValidationProvider).applyResult({
+  errors: ["this is a backend error"],
+  valid: false,
+  failedRules: {}
+});
+```
+
+:::
+
 ## Reference
 
 Below is the reference of the ValidationProvider public API.

--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -1,4 +1,4 @@
-import Vue = require("vue")
+import Vue from 'vue';
 
 export interface VeeValidateComponentOptions {
     validator?: 'new' | 'inherit';
@@ -74,7 +74,7 @@ export class Field {
     el: any;
     value: any;
     rules: any;
-    update(options:object): void;
+    update(options: object): void;
 }
 
 export interface ErrorField {
@@ -106,8 +106,8 @@ export class ErrorBag {
 
 export class FieldBag {
     items: Field[];
-    filter(matcher: {name?: string, scope?: string, id?: string}): Field[];
-    find(matcher: {name?: string, scope?: string, id?: string}): Field | undefined;
+    filter(matcher: { name?: string, scope?: string, id?: string }): Field[];
+    find(matcher: { name?: string, scope?: string, id?: string }): Field | undefined;
     map(fn: Function): Field[];
 }
 
@@ -138,7 +138,7 @@ export interface ValidationSlotScopeData {
     flags: FieldFlags;
     valid: boolean;
     failedRules: { [x: string]: string };
-    reset (): void;
+    reset(): void;
     validate(value?: any): Promise<VerifyResult>
 }
 
@@ -155,25 +155,25 @@ export class Validator {
     static readonly dictionary: any;
 
     constructor(validations?: any, options?: any);
-    attach(name: string, checks: string|Object, options?: Object): Field;
+    attach(name: string, checks: string | Object, options?: Object): Field;
     attach(options: FieldOptions): Field;
     reset(matcher?: FieldMatchOptions): Promise<void>;
     detach(name: string, scope?: string): void;
-    extend(name: string, validator: Object|Function, options?:ExtendOptions): void;
+    extend(name: string, validator: Object | Function, options?: ExtendOptions): void;
     flag(name: string, flags: Object): void;
     pause(): Validator;
     remove(name: string): void;
     update(id: string, diff: Object): void;
     resume(): Validator;
-    localize(rootDictionary?: Object) :void;
-    localize(language: string, dictionary?: Object) :void;
+    localize(rootDictionary?: Object): void;
+    localize(language: string, dictionary?: Object): void;
     setStrictMode(strictMode?: boolean): void;
     validate(name?: string, value?: any, scope?: string, silent?: boolean): Promise<any>;
     validateAll(values?: Object, scope?: string, silent?: boolean): Promise<any>;
     validateScopes(silent?: boolean): Promise<any>;
-    verify(value: any, rules: string|Object, options?: VerifyOptions): Promise<VerifyResult>;
+    verify(value: any, rules: string | Object, options?: VerifyOptions): Promise<VerifyResult>;
     static create(validations: Object, options: any): Validator;
-    static extend(name: string, validator: Object|Function, options?:ExtendOptions): void;
+    static extend(name: string, validator: Object | Function, options?: ExtendOptions): void;
     static remove(name: string): void;
     static setStrictMode(strictMode?: boolean): void;
     static localize(rootDictionary: Object): void;
@@ -181,33 +181,61 @@ export class Validator {
 }
 
 export class ExtendOptions {
-  hasTarget?: boolean;
-  paramNames?: string[];
-  computesRequired?: Boolean
-  initial?: Boolean
+    hasTarget?: boolean;
+    paramNames?: string[];
+    computesRequired?: Boolean
+    initial?: Boolean
 }
 
 /**
  * `mapFields` helper, which is similar to Vuex's `mapGetters` and `mapActions`
  * as it maps a field object to a computed property.
  */
-export function mapFields(fields?: string[]|{[key: string]: string}): any;
+export function mapFields(fields?: string[] | { [key: string]: string }): any;
+
+export interface ObserverSlotData {
+    errors: string[];
+    untouched: boolean;
+    touched: boolean;
+    dirty: boolean;
+    pristine: boolean;
+    valid: boolean | null;
+    invalid: boolean | null;
+    validated: boolean;
+    required: boolean;
+    pending: boolean;
+}
 
 /**
  * The `ValidationObserver` is a convenient component that uses the `scoped slots` feature
  * to communicate the current state of your inputs as a whole.
  * Note that this component is renderless.
  */
-export const ValidationObserver: Vue.Component;
+export class ValidationObserver extends Vue {
+    validate (): Promise<boolean>;
+    reset (): void;
+    observers: ValidationObserver[];
+    refs: { [x: string]: ValidationProvider };
+    ctx: ObserverSlotData;
+};
 
 /**
  * The `ValidationProvider` component is a regular component
  * that wraps your inputs and provides validation state using `scoped slots`.
  * Note that this component is renderless.
  */
-export const ValidationProvider: Vue.Component;
+export class ValidationProvider extends Vue {
+    messages: string[];
+    flags: FieldFlags;
+    applyResult(result: VerifyResult): void;
+    validate(value: any): Promise<VerifyResult>;
+    reset(): void;
+    validateSilent(): Promise<VerifyResult>;
+    syncValue(value: any): void;
+    setFlags(value: { [x: string]: boolean }): void;
+}
 
-export const withValidation: (component: Vue.Component, mapFn: (ctx: ValidationSlotScopeData) => Object) => Vue.Component;
+export const withValidation: (component: Vue, mapFn: (ctx: ValidationSlotScopeData) => Object) => Vue.Component;
 
 export const version: string;
 
@@ -217,7 +245,7 @@ export const directive: Vue.DirectiveOptions;
 
 export const Rules: {
     [key: string]: {
-        validate (value: any, args: Object | any[], data?: any): boolean | Promise<boolean>;
+        validate(value: any, args: Object | any[], data?: any): boolean | Promise<boolean>;
         options?: object;
         paramNames?: string[];
     }


### PR DESCRIPTION
This adds public data/methods typings to the validation provider and observer components so that they can be used as cast targets for typescript when using `refs`.

```vue
<template>
  <div id="app">
    <ValidationProvider ref="someRef" rules="required">
      <div slot-scope="{ errors }">
        <input v-model="model" type="text">
        <div v-if="errors" v-text="errors[0]"></div>
      </div>
    </ValidationProvider>
  </div>
</template>

<script lang="ts">
import { Component, Vue } from "vue-property-decorator";
import HelloWorld from "./components/HelloWorld.vue";
import { ValidationProvider, ValidationObserver } from "vee-validate";

@Component({
  components: {
    ValidationProvider
  },
  mounted() {
    (this.$refs.someRef as ValidationProvider).applyResult({
      errors: ["this is a backend error"],
      valid: false,
      failedRules: {}
    });
  }
})
export default class App extends Vue {}
</script>
```

closes #1938 