### PR TITLE
Feat/silent validation observer

### DIFF
--- a/docs/guide/components/validation-observer.md
+++ b/docs/guide/components/validation-observer.md
@@ -52,7 +52,7 @@ The scoped slot is passed an object containing a flags object representing the m
 | touched   | `boolean`                   | True if at least one field has been touched (blurred).                                      |
 | untouched | `boolean`                   | True if all fields haven't been touched (blurred).                                           |
 | errors    | `{ [x: string]: string[] }` | An object containing reference to each field errors, each field is keyed by its `vid` prop. |
-| validate  | `() => { then: () => Promise<any> }` | A method that triggers validation for all providers. Can be chained using `then` to run a method after successful validation. |
+| validate  | `({ silent: boolean }) => { then: () => Promise<any> }` | A method that triggers validation for all providers. Can be chained using `then` to run a method after successful validation. Mutates child providers state unless `silent` is true. |
 | reset     | `() => void`                | A method that resets validation state for all providers. |
 
 ## Examples
@@ -176,7 +176,7 @@ Those are the only methods meant for public usage, other methods that may exist 
 
 |Method       | Args    | Return Value                  | Description                                                     |
 |-------------|:-------:|:-----------------------------:|-----------------------------------------------------------------|
-| validate    | `void`  | `Promise<boolean>`            | Validates all the child providers/observers and also mutates their state. |
+| validate    | `{ silent: boolean }`  | `Promise<boolean>` | Validates all the child providers/observers and mutates their state unless `silent` is true. |
 | reset       | `void`  | `void`                        | Resets validation state for all child providers/observers.                |
 
 ### Events

--- a/src/components/observer.js
+++ b/src/components/observer.js
@@ -53,8 +53,8 @@ export const ValidationObserver = {
     ctx () {
       const ctx = {
         errors: {},
-        validate: () => {
-          const promise = this.validate();
+        validate: (arg) => {
+          const promise = this.validate(arg);
 
           return {
             then (thenable) {
@@ -144,10 +144,10 @@ export const ValidationObserver = {
         this.observers.splice(idx, 1);
       }
     },
-    validate () {
+    validate ({ silent } = { silent: false }) {
       return Promise.all([
-        ...values(this.refs).map(ref => ref.validate().then(r => r.valid)),
-        ...this.observers.map(obs => obs.validate())
+        ...values(this.refs).map(ref => ref[silent ? 'validateSilent' : 'validate']().then(r => r.valid)),
+        ...this.observers.map(obs => obs.validate({ silent }))
       ]).then(results => results.every(r => r));
     },
     reset () {


### PR DESCRIPTION
This PR adds options for the validate method on the Observer instances and their slotScope data. This allows the users to trigger silent validations across the tree of Provider and Observer components.

```vue
<ValidationObserver v-slot="{ validate }" ref="obs">
  <ValidationProvider rules="required" v-slot="{ errors }">
    <input type="text" v-model="one">
    {{ errors [0] }}
  </ValidationProvider>
  <button @click="validate({ silent: true })">Silent</button>
</ValidationObserver>
```

closes #1948