### PR TITLE
fix #1967

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -307,7 +307,7 @@ export const ValidationProvider = {
       return Object.keys(rules).filter(RuleContainer.isTargetRule).map(rule => {
         const depName = rules[rule][0];
         const watcherName = `$__${depName}`;
-        if (!isCallable(this[watcherName])) {
+        if (!isCallable(this[watcherName]) && providers[depName]) {
           this[watcherName] = providers[depName].$watch('value', () => {
             if (this.flags.validated) {
               this._needsValidation = true;


### PR DESCRIPTION
This PR adds a check for the cross-field existence before attempting to call `$watch` which should prevent unnecessary crashes/errors during building the cross-field value table.

closes #1967