### PR TITLE
fix ru locale grammatical case

### DIFF
--- a/locale/ru.js
+++ b/locale/ru.js
@@ -13,7 +13,7 @@ const messages = {
   credit_card: (field) => `Поле ${field} должно быть действительным номером карты`,
   date_between: (field, [min, max]) => `Поле ${field} должно быть между ${min} и ${max}.`,
   date_format: (field, [format]) => `Поле ${field} должно быть в формате ${format}.`,
-  decimal: (field, [decimals = '*'] = []) => `Поле ${field} должно быть числовым и может содержать${decimals === '*' ? '' : ' ' + decimals} десятичных числа.`,
+  decimal: (field, [decimals = '*'] = []) => `Поле ${field} должно быть числовым и может содержать${decimals === '*' ? ' десятичные числа' : ' ' + decimals + ' десятичных чисел'}.`,
   digits: (field, [length]) => `Поле ${field} должно быть числовым и точно содержать ${length} цифры.`,
   dimensions: (field, [width, height]) => `Поле ${field} должно быть ${width} пикселей на ${height} пикселей.`,
   email: (field) => `Поле ${field} должно быть действительным электронным адресом.`,


### PR DESCRIPTION
🔎 __Overview__

This PR changes the ru locale `decimal` messages style because: it's wrong grammatical case if there is no digits

✔ __Issues affected__
nope
