### PR TITLE
Translate the "is" rule messages in pt_PT and pt_BR languages

### DIFF
--- a/locale/pt_BR.js
+++ b/locale/pt_BR.js
@@ -22,6 +22,7 @@ const messages = {
   included: (field) => `O campo ${field} deve ter um valor válido.`,
   integer: (field) => `O campo ${field} deve ser um número inteiro.`,
   ip: (field) => `O campo ${field} deve ser um endereço IP válido.`,
+  is: (field) => `O valor inserido no campo ${field} não é válido.`,
   length: (field, [length, max]) => {
     if (max) {
       return `O tamanho do campo ${field} está entre ${length} e ${max}.`;

--- a/locale/pt_PT.js
+++ b/locale/pt_PT.js
@@ -20,6 +20,7 @@ const messages = {
   image: (field) => `O campo ${field} deve ser uma imagem.`,
   included: (field) => `O campo ${field} deve ter um valor válido.`,
   ip: (field) => `O campo ${field} deve ser um endereço IP válido.`,
+  is: (field) => `O valor inserido no campo ${field} não é válido.`,
   max: (field, [length]) => `O campo ${field} não deve ter mais que ${length} caracteres.`,
   max_value: (field, [max]) => `O campo ${field} precisa ser ${max} ou menor.`,
   mimes: (field) => `O campo ${field} deve ser um tipo de ficheiro válido.`,


### PR DESCRIPTION
This PR adds the message translations in pt_PT and pt_BR of the rule: [is](https://baianat.github.io/vee-validate/guide/rules.html#is).
