### PR TITLE
[#1936] added: use change input event if vnode.tag is equal to 'select'

### DIFF
--- a/src/utils/vnode.js
+++ b/src/utils/vnode.js
@@ -111,8 +111,8 @@ export function getInputEventName (vnode, model) {
     return event;
   }
 
-  // Lazy Models typically use change event
-  if (model && model.modifiers && model.modifiers.lazy) {
+  // Lazy Models and select tag typically use change event
+  if ((model && model.modifiers && model.modifiers.lazy) || vnode.tag === 'select') {
     return 'change';
   }
 


### PR DESCRIPTION
🔎 __Overview__

If the select use an attribute (like `name` or `id`) the `getInputEventName` method see the `select` like a base `input`

Ex (Feat):
> This PR fixes the #1936.

✔ __Issues affected__

> closes #1936
