### PR TITLE
Add verbose error when path isn't within object

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -148,15 +148,29 @@ export const getPath = (path: string, target: ?Object, def: any = undefined) => 
  */
 export const hasPath = (path: string, target: Object) => {
   let obj = target;
-  return path.split('.').every(prop => {
-    if (prop in obj) {
-      obj = obj[prop];
-
-      return true;
+  let previousPath = null;
+  let isNullOrNonObject = false;
+  const isValidPath = path.split('.').reduce((reducer, prop) => {
+    if (obj == null || typeof obj != 'object') {
+      isNullOrNonObject = true;
+      return reducer && false;
     }
 
-    return false;
-  });
+    if (prop in obj) {
+      obj = obj[prop];
+      previousPath = previousPath === null ? prop : previousPath + '.' + prop;
+
+      return reducer && true;
+    }
+
+    return reducer && false;
+  }, true);
+
+  if (isNullOrNonObject) {
+    throw new Error(previousPath + ' is not an object');
+  }
+
+  return isValidPath;
 };
 
 /**

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -202,13 +202,25 @@ test('checks if a value path with exists', () => {
   const some = {
     value: {
       path: undefined,
-      val: 1
+      nullValue: null,
+      val: 1,
+      someString: ''
     }
   };
 
   expect(utils.hasPath('value.val', some)).toBe(true); // exists.
   expect(utils.hasPath('value.path', some)).toBe(true); // undefined but exists.
-  expect(utils.hasPath('value.not', some)).toBe(false); // does not.
+  expect(utils.hasPath('value.nullValue', some)).toBe(true); // null but exists.
+  expect(utils.hasPath('value.notExist', some)).toBe(false); // does not.
+  expect(() => {
+    utils.hasPath('value.val.notExistAttr', some);
+  }).toThrow('value.val is not an object'); // throw error because not object.
+  expect(() => {
+    utils.hasPath('value.someString.notExistAttr', some);
+  }).toThrow('value.someString is not an object'); // throw error because not object.
+  expect(() => {
+    utils.hasPath('value.nullValue.notExistAttr', some);
+  }).toThrow('value.nullValue is not an object'); // throw error because not object.
 });
 
 test('gets the value path with a fallback value', () => {


### PR DESCRIPTION
🔎 __Overview__

Recently, I had an error
`Uncaught TypeError: Cannot use 'in' operator to search for 'someKeyHere' in`
While I debug things, I think it's better to have a full path as part of stack trace.

WDYT ?

Ex (Feat):
> This PR {adds/fixes/improves} the {feature/bug/something}.

Ex (Locale):
> This PR changes the {locale} messages style because {reason}

🤓 __Code snippets/examples (if applicable)__

```js
// some code
```

✔ __Issues affected__

list of issues formatted like this:

> closes #{issue id}
