### PR TITLE
docs(rules): display message for password_confirmation

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -171,6 +171,7 @@ The field under validation must have the same value as the confirmation field.
 <span v-show="errors.has('password')" class="help is-danger">{{ errors.first('password') }}</span>
 
 <input v-validate="'required|confirmed:password'" name="password_confirmation" type="password" :class="{'is-danger': errors.has('password_confirmation')}" placeholder="Password, Again" data-vv-as="password">
+<span v-show="$errors.has('password_confirmation')" class="help is-danger">{{ this.$errors.first('password_confirmation') }}</span>
 ```
 
 ::: tip


### PR DESCRIPTION
It looks like you forgot to include this line which can be misleading for people who want to test this code.

🔎 __Overview__

Explain the premise for adding this PR and why is it important.

Ex (Feat):
> This PR {adds/fixes/improves} the {feature/bug/something}.

Ex (Locale):
> This PR changes the {locale} messages style because {reason}

🤓 __Code snippets/examples (if applicable)__

```js
// some code
```

✔ __Issues affected__

list of issues formatted like this:

> closes #{issue id}
