### PR TITLE
Fix typescript error

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -217,7 +217,7 @@ export class ValidationObserver extends Vue {
     observers: ValidationObserver[];
     refs: { [x: string]: ValidationProvider };
     ctx: ObserverSlotData;
-};
+}
 
 /**
  * The `ValidationProvider` component is a regular component


### PR DESCRIPTION
🔎 __Overview__

Fixes Statements are not allowed in ambient contexts when using typescript