### PR TITLE
feat: handle array of objects in validateAll

### DIFF
--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -369,7 +369,7 @@ export default class Validator {
       providedValues = true;
     } else if (Array.isArray(values)) {
       matcher = values.map(key => {
-        return { name: key, vmId: vmId };
+        return typeof key === 'object' ? Object.assign({ vmId: vmId }, key) : { name: key, vmId: vmId };
       });
     } else {
       matcher = { scope: null, vmId: vmId };


### PR DESCRIPTION
🔎 __Overview__

It was not possible to do a `validateAll` toward a list of fields while specifying their scope. Not even with a common scope.

This PR will allow to do that with an array-typed argument: objects will be treated as matchers, with a default `vmId` assignment. Strings are treated like before (non-breaking): as name-targetted values.

🤓 __Code snippets/examples__

```js
await this.$validator.validateAll([
  'my_field_name',
  { name: 'my_scoped_field_name', scope: 'my_scope' },
  { name: 'my_scoped_field_name', scope: 'my_scope2' },
  'my_other_field_name'
  // etc.
]);
```

So bad that I'm coming just 4 hours after the last release :(