### PR TITLE
fix: enable pass args to the i18n messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vee-validate",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Template Based Validation Framework for Vue.js",
   "author": "Abdelrahman Awad <logaretm1@gmail.com>",
   "license": "MIT",

--- a/src/localization/i18n.js
+++ b/src/localization/i18n.js
@@ -67,17 +67,23 @@ export default class I18nDictionary implements IDictionary {
 
   getMessage (_, key: string, data: any[]): string {
     const path = `${this.rootKey}.messages.${key}`;
+    let dataOptions = data;
+
+    if (Array.isArray(data)) {
+      dataOptions = [].concat.apply([], data);
+    }
+
     if (this.i18n.te(path)) {
-      return this.i18n.t(path, data);
+      return this.i18n.t(path, dataOptions);
     }
 
     // fallback to the fallback message
     if (this.i18n.te(path, this.i18n.fallbackLocale)) {
-      return this.i18n.t(path, this.i18n.fallbackLocale, data);
+      return this.i18n.t(path, this.i18n.fallbackLocale, dataOptions);
     }
 
     // fallback to the root message
-    return this.i18n.t(`${this.rootKey}.messages._default`, data);
+    return this.i18n.t(`${this.rootKey}.messages._default`, dataOptions);
   }
 
   getAttribute (_, key: string, fallback?: string = ''): string {


### PR DESCRIPTION
Flat array params for detect one or more params

🔎 __Overview__

As reported in the issue #1607, vue-i18n default adapter has a limitation. When multiple params are required (e.g.: min, max) both are sended like a only one array. This is a weird behavior, because the pattern adopted (and also explained by some developers that use vue-i18n) is that each value is an argument. Vue-i18n lib has an abstraction for array-like objects thats works fine.