### PR TITLE
Translated required_if to german

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -38,6 +38,7 @@ const messages = {
   numeric: (field) => `${field} darf nur numerische Zeichen enthalten.`,
   regex: (field) => `Das Format von ${field} ist ungültig.`,
   required: (field) => `${field} ist ein Pflichtfeld.`,
+  required_if: (field) => `${field} ist ein Pflichtfeld.`,
   size: (field, [size]) => `${field} muss kleiner als ${formatFileSize(size)} sein.`,
   url: (field) => `${field} ist keine gültige URL.`,
 };


### PR DESCRIPTION
Ex (Locale):
> This PR adds the german message for required_if, since it is missing.
