### PR TITLE
feat: optimize finding fields by id

### DIFF
--- a/src/core/fieldBag.js
+++ b/src/core/fieldBag.js
@@ -5,9 +5,14 @@ import { find, createError } from '../utils';
 
 export default class FieldBag {
   items: Array<Field>;
+  itemsById: Object;
 
   constructor (items = []) {
     this.items = items || [];
+    this.itemsById = this.items.reduce((itemsById, item) => {
+      itemsById[item.id] = item;
+      return itemsById;
+    }, {});
   }
 
   [typeof Symbol === 'function' ? Symbol.iterator : '@@iterator'] () {
@@ -32,6 +37,14 @@ export default class FieldBag {
    */
   find (matcher: Object): ?Field {
     return find(this.items, item => item.matches(matcher));
+  }
+
+  /**
+   * Finds the field with the given id, using a plain object as a map to link
+   * ids to items faster than by looping over the array and matching.
+   */
+  findById (id: String): ?Field {
+    return this.itemsById[id] || null;
   }
 
   /**
@@ -68,6 +81,7 @@ export default class FieldBag {
 
     const index = this.items.indexOf(item);
     this.items.splice(index, 1);
+    delete this.itemsById[item.id];
 
     return item;
   }
@@ -84,10 +98,11 @@ export default class FieldBag {
       throw createError('Field id must be defined.');
     }
 
-    if (this.find({ id: item.id })) {
+    if (this.findById(item.id)) {
       throw createError(`Field with id ${item.id} is already added.`);
     }
 
     this.items.push(item);
+    this.itemsById[item.id] = item;
   }
 }

--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -678,7 +678,7 @@ export default class Validator {
    */
   _resolveField (name: string, scope: string | null, uid): ?Field {
     if (name[0] === '#') {
-      return this.fields.find({ id: name.slice(1) });
+      return this.fields.findById(name.slice(1));
     }
 
     if (!isNullOrUndefined(scope)) {

--- a/src/directive.js
+++ b/src/directive.js
@@ -12,7 +12,7 @@ function findField (el: HTMLElement, context: ValidatingVM): ?Field {
     return null;
   }
 
-  return context.$validator.fields.find({ id: el._veeValidateId });
+  return context.$validator.fields.findById(el._veeValidateId);
 };
 
 export default {


### PR DESCRIPTION
🔎 __Overview__

This PR improves the performance of finding fields by id, using a plain object as a map to link ids to items faster than by looping over the array and matching.

In my profiling of large forms with many fields with validation, the repeated looping over the fields triggered by `findField()` in `src/directive.js` had a serious performance impact that showed up as hundreds of milliseconds in my profiling. 

This simple optimization removes that bottleneck.
