### PR TITLE
fix: make `yarn lint` not fail

### DIFF
--- a/src/rules/ip_or_fqdn.js
+++ b/src/rules/ip_or_fqdn.js
@@ -16,7 +16,7 @@ const validate = (value) => {
 
 export {
   validate
-  };
+};
 
 export default {
   validate

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -275,6 +275,7 @@ test('calls functions immediatly if time is 0', done => {
 test('warns with branded message', () => {
   global.console = { warn: jest.fn() };
   utils.warn('Something is not right');
+  // eslint-disable-next-line no-console
   expect(console.warn).toHaveBeenCalledWith('[vee-validate] Something is not right');
 });
 


### PR DESCRIPTION
🔎 __Overview__

> This PR fixes the execution of `yarn lint` at root level:

```sh
yarn lint
yarn run v1.12.1
$ eslint src tests --fix

vee-validate/tests/unit/utils.js
  278:10  error  Unexpected console statement  no-console

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command
```
