### PR TITLE
fix(rules): clone options passed to `validator.js` + code tweaks (closes #2018)

### DIFF
--- a/src/rules/decimal.js
+++ b/src/rules/decimal.js
@@ -1,10 +1,12 @@
+import { isNullOrUndefined } from '../utils';
+
 const validate = (value, { decimals = '*', separator = '.' } = {}) => {
-  if (Array.isArray(value)) {
-    return value.every(val => validate(val, { decimals, separator }));
+  if (isNullOrUndefined(value) || value === '') {
+    return false;
   }
 
-  if (value === null || value === undefined || value === '') {
-    return false;
+  if (Array.isArray(value)) {
+    return value.every(val => validate(val, { decimals, separator }));
   }
 
   // if is 0.
@@ -22,7 +24,7 @@ const validate = (value, { decimals = '*', separator = '.' } = {}) => {
   const parsedValue = parseFloat(value);
 
   // eslint-disable-next-line
-    return parsedValue === parsedValue;
+  return parsedValue === parsedValue;
 };
 
 const paramNames = ['decimals', 'separator'];

--- a/src/rules/email.js
+++ b/src/rules/email.js
@@ -1,15 +1,18 @@
 import isEmail from 'validator/lib/isEmail';
+import { assign } from '../utils';
 
-const validate = (value, options = {}) => {
-  if (options.multiple) {
-    value = value.split(',').map(emailStr => emailStr.trim());
+const validate = (value, { multiple = false, ...options } = {}) => {
+  if (multiple && !Array.isArray(value)) {
+    value = String(value).split(',').map(emailStr => emailStr.trim());
   }
+
+  const validatorOptions = assign({}, options);
 
   if (Array.isArray(value)) {
-    return value.every(val => isEmail(String(val), options));
+    return value.every(val => isEmail(String(val), validatorOptions));
   }
 
-  return isEmail(String(value), options);
+  return isEmail(String(value), validatorOptions);
 };
 
 export {

--- a/src/rules/length.js
+++ b/src/rules/length.js
@@ -1,4 +1,4 @@
-import { toArray } from '../utils';
+import { isNullOrUndefined, toArray } from '../utils';
 
 /**
  * @param {Array|String} value
@@ -17,11 +17,11 @@ const compare = (value, length, max) => {
 };
 
 const validate = (value, [length, max = undefined]) => {
-  length = Number(length);
-  if (value === undefined || value === null) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 
+  length = Number(length);
   if (typeof value === 'number') {
     value = String(value);
   }

--- a/src/rules/max.js
+++ b/src/rules/max.js
@@ -1,5 +1,7 @@
+import { isNullOrUndefined } from '../utils';
+
 const validate = (value, [length]) => {
-  if (value === undefined || value === null) {
+  if (isNullOrUndefined(value)) {
     return length >= 0;
   }
 

--- a/src/rules/max_value.js
+++ b/src/rules/max_value.js
@@ -1,5 +1,7 @@
+import { isNullOrUndefined } from '../utils';
+
 const validate = (value, [max]) => {
-  if (value === null || value === undefined || value === '') {
+  if (isNullOrUndefined(value) || value === '') {
     return false;
   }
 

--- a/src/rules/min.js
+++ b/src/rules/min.js
@@ -1,5 +1,7 @@
+import { isNullOrUndefined } from '../utils';
+
 const validate = (value, [length]) => {
-  if (value === undefined || value === null) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 

--- a/src/rules/min_value.js
+++ b/src/rules/min_value.js
@@ -1,5 +1,7 @@
+import { isNullOrUndefined } from '../utils';
+
 const validate = (value, [min]) => {
-  if (value === null || value === undefined || value === '') {
+  if (isNullOrUndefined(value) || value === '') {
     return false;
   }
 

--- a/src/rules/required.js
+++ b/src/rules/required.js
@@ -1,16 +1,12 @@
-import { isEmptyArray } from '../utils';
+import { isEmptyArray, isNullOrUndefined } from '../utils';
 
 const validate = (value, [invalidateFalse = false] = []) => {
-  if (isEmptyArray(value)) {
+  if (isNullOrUndefined(value) || isEmptyArray(value)) {
     return false;
   }
 
   // incase a field considers `false` as an empty value like checkboxes.
   if (value === false && invalidateFalse) {
-    return false;
-  }
-
-  if (value === undefined || value === null) {
     return false;
   }
 

--- a/src/rules/url.js
+++ b/src/rules/url.js
@@ -1,16 +1,18 @@
 import isURL from 'validator/lib/isURL';
-import { isNullOrUndefined } from '../utils';
+import { assign, isNullOrUndefined } from '../utils';
 
 const validate = (value, options = {}) => {
   if (isNullOrUndefined(value)) {
     value = '';
   }
 
+  const validatorOptions = assign({}, options);
+
   if (Array.isArray(value)) {
-    return value.every(val => isURL(val, options));
+    return value.every(val => isURL(val, validatorOptions));
   }
 
-  return isURL(value, options);
+  return isURL(value, validatorOptions);
 };
 
 export {


### PR DESCRIPTION
🔎 __Overview__

This PR makes sure to only pass cloned `options` to [validator.js](https://github.com/chriso/validator.js) since they get extended by the default options.

The `email` validator code is made more robust by checking if the `value` is an Array when `multiple` is set and `multiple` is exclude from the `options` passed to the `isEmail()` validator.

Also make sure to use `isNullOrUndefined()` util in rules wherever possible.

✔ __Issues affected__

Closes #2018.
