### PR TITLE
Update sv.js

### DIFF
--- a/locale/sv.js
+++ b/locale/sv.js
@@ -10,7 +10,7 @@ const messages = {
   between: (field, [min, max]) => `Fältet ${field} måste vara mellan ${min} och ${max}.`,
   confirmed: (field, [target]) => `Fältet ${field} matchar inte ${target}.`,
   date_between: (field, [min, max]) => `Fältet ${field} måste vara mellan ${min} och ${max}.`,
-  date_format: (field, [target]) => `Fältet ${field} måste ha formatatet ${target}.`,
+  date_format: (field, [target]) => `Fältet ${field} måste ha formatet ${target}.`,
   decimal: (field, [decimals = '*'] = []) => `Fältet ${field} måste vara numeriskt och får innehålla ${(decimals === '*' ? '' : decimals)} decimaltecken.`,
   digits: (field, [length]) => `Fältet ${field} måste vara numeriskt och innehålla exakt ${length} siffor.`,
   dimensions: (field, [width, height]) => `Fältet ${field} måste vara ${width} pixlar bred och ${height} pixlar hög.`,


### PR DESCRIPTION
formatatet is spelled wrong should be formatet

🔎 __Overview__
The translation is wrong the spelling should be formatet not formatatet


✔ __Issues affected__

Version:
vee-validate: 2.2.0

There is a spelling mistake in the Swedish translation of one of the validation error texts.
The file sv.js contains the following:

date_format: (field, [target]) => Fältet ${field} måste ha formatatet ${target}.

But the word "formatatet" does not exist in Swedish. It should in fact be "formatet" instead.

Use google translate to verify this is the case.

> closes #2024
