### PR TITLE
fix(rules): improve file/files handling

### DIFF
--- a/src/rules/dimensions.js
+++ b/src/rules/dimensions.js
@@ -1,3 +1,7 @@
+import { ensureArray } from '../utils';
+
+const imageRegex = /\.(jpg|svg|jpeg|png|bmp|gif)$/i;
+
 const validateImage = (file, width, height) => {
   const URL = window.URL || window.webkitURL;
   return new Promise(resolve => {
@@ -12,18 +16,11 @@ const validateImage = (file, width, height) => {
 };
 
 const validate = (files, [width, height]) => {
-  if (!Array.isArray(files)) files = [files];
-  const list = [];
-  for (let i = 0; i < files.length; i++) {
-    // if file is not an image, reject.
-    if (! /\.(jpg|svg|jpeg|png|bmp|gif)$/i.test(files[i].name)) {
-      return false;
-    }
-
-    list.push(files[i]);
+  const images = ensureArray(files).filter(file => imageRegex.test(file.name));
+  if (images.length === 0) {
+    return false;
   }
-
-  return Promise.all(list.map(file => validateImage(file, width, height)));
+  return Promise.all(images.map(image => validateImage(image, width, height)));
 };
 
 export {

--- a/src/rules/ext.js
+++ b/src/rules/ext.js
@@ -1,7 +1,8 @@
+import { ensureArray } from '../utils';
+
 const validate = (files, extensions) => {
   const regex = new RegExp(`.(${extensions.join('|')})$`, 'i');
-
-  return (Array.isArray(files) ? files : [files]).every(file => regex.test(file.name));
+  return ensureArray(files).every(file => regex.test(file.name));
 };
 
 export {

--- a/src/rules/mimes.js
+++ b/src/rules/mimes.js
@@ -1,7 +1,8 @@
+import { ensureArray } from '../utils';
+
 const validate = (files, mimes) => {
   const regex = new RegExp(`${mimes.join('|').replace('*', '.+')}$`, 'i');
-
-  return (Array.isArray(files) ? files : [files]).every(file => regex.test(file.type));
+  return ensureArray(files).every(file => regex.test(file.type));
 };
 
 export {

--- a/src/rules/size.js
+++ b/src/rules/size.js
@@ -1,17 +1,11 @@
+import { ensureArray } from '../utils';
+
 const validate = (files, [size]) => {
-  if (!Array.isArray(files)) files = [files];
   if (isNaN(size)) {
     return false;
   }
-
   const nSize = Number(size) * 1024;
-  for (let i = 0; i < files.length; i++) {
-    if (files[i].size > nSize) {
-      return false;
-    }
-  }
-
-  return true;
+  return ensureArray(files).every(file => file.size <= nSize);
 };
 
 export {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -381,6 +381,17 @@ export const toArray = (arrayLike: { length: number }) => {
 };
 
 /**
+ * Converts an array-like object to array and place other elements in an array
+ */
+export const ensureArray = (arrayLike: any): array => {
+  if (Array.isArray(arrayLike)) {
+    return [...arrayLike];
+  }
+  const array = toArray(arrayLike);
+  return isEmptyArray(array) ? [arrayLike] : array;
+};
+
+/**
  * Assign polyfill from the mdn.
  */
 export const assign = (target: Object, ...others: any[]) => {

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -44,9 +44,10 @@ export default {
       }
     };
   },
-  file: (name, type, size = 1) => ({
-    name,
-    type,
-    size: size * 1024
+  file: (name, type, size = 1) => new File([new ArrayBuffer(size * 1024)], name, { type }),
+  fileList: (files) => ({
+    length: files.length,
+    item: (index) => files[index],
+    ...files
   })
 };

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -2,6 +2,7 @@ import * as utils from '@/utils';
 import * as dateUtils from '@/utils/date';
 import * as i18Utils from '../../locale/utils';
 import * as eventUtils from '@/utils/events';
+import helpers from '../helpers';
 
 test('gets the data attribute prefixed with the plugin', () => {
   document.body.innerHTML =
@@ -196,6 +197,17 @@ test('converts array like objects to arrays', () => {
 
   let array = utils.toArray(nodeList);
   expect(Array.isArray(array)).toBe(true);
+});
+
+test('converts file list or single file to array of files', () => {
+  const file = helpers.file('file.jpg', 'image/jpeg', 10);
+  expect(Array.isArray(file)).toBe(false);
+
+  const fileList = helpers.fileList([file]);
+  expect(Array.isArray(fileList)).toBe(false);
+
+  expect(Array.isArray(utils.ensureArray(file))).toBe(true);
+  expect(Array.isArray(utils.ensureArray(fileList))).toBe(true);
 });
 
 test('checks if a value path with exists', () => {


### PR DESCRIPTION
🔎 __Overview__

This is a follow-up PR to #2031 and introduces a new `ensureArray()` util to create an array from a single object like an `File` or an array-like object like an `FileList`.

Tests for the new util are also added and it's used in any rule that handles files.