### PR TITLE
feat: add json rule

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -25,6 +25,7 @@ VeeValidate comes with a bunch of validation rules out of the box and they are a
 - [ip_or_fqdn](#ip_or_fqdn)
 - [is](#is)
 - [is_not](#is-not)
+- [json](#json)
 - [length](#length)
 - [max](#max)
 - [max_value](#max-value)
@@ -384,6 +385,22 @@ A negated version of [is](#is) rule, also uses the `===` for equality checks.
 ```html
 <input v-validate="{ is_not: duplicate }" type="text" name="field">
 <input v-model="duplicate" type="text" name="not_again">
+```
+
+## json
+
+The field under validation must have a string that is a valid json value.
+
+### json params
+
+- `type:` A json is specific type of json. The possible values :
+- `array`: Accept only json array (ex: `["value",{"key":"value"}]`)
+- `array_object`: Accept only json array and value is only object (ex: `[{"key":"value"},{"key":"value"}]`)
+- `object`: Accept only json object (ex: `{"key":"value"}`)
+- `all` (default): Accept all json (array and object)
+
+```html
+<input v-validate="'type:array_object'" type="text" name="field">
 ```
 
 ## length

--- a/locale/en.js
+++ b/locale/en.js
@@ -24,6 +24,16 @@ const messages = {
   integer: (field) => `The ${field} field must be an integer.`,
   ip: (field) => `The ${field} field must be a valid ip address.`,
   ip_or_fqdn: (field) => `The ${field} field must be a valid ip address or FQDN.`,
+  json: (field, {type}) => {
+    let typeStr = ''
+    switch(type) {
+      case 'array_object':
+        typeStr = 'array of object';
+        break;
+    }
+
+    return `The ${field} field must be an valid json ${typeStr}.`;
+  },
   length: (field, [length, max]) => {
     if (max) {
       return `The ${field} length must be between ${length} and ${max}.`;

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -23,6 +23,22 @@ const messages = {
   included: (field) => `Le champ ${field} doit être une valeur valide.`,
   integer: (field) => `Le champ ${field} doit être un entier.`,
   ip: (field) => `Le champ ${field} doit être une adresse IP.`,
+  json: (field, {type}) => {
+    let typeStr = 'un'
+    switch(type) {
+      case 'array_object':
+        typeStr = 'une liste d\'objet';
+        break;
+      case 'array':
+        typeStr = 'une liste';
+        break;
+      case 'object':
+        typeStr = 'un objet';
+        break;
+    }
+
+    return `Le champ ${field} doit être ${typeStr} json valide.`;
+  },
   length: (field, [length, max]) => {
     if (max) {
       return `Le champ ${field} doit contenir entre ${length} et ${max} caractères.`;

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -23,6 +23,7 @@ import ip from './ip';
 import ip_or_fqdn from './ip_or_fqdn';
 import is from './is';
 import is_not from './is_not';
+import json from './json';
 import length from './length';
 import max from './max';
 import max_value from './max_value';
@@ -61,6 +62,7 @@ export {
   ip_or_fqdn,
   is_not,
   is,
+  json,
   max,
   max_value,
   mimes,

--- a/src/rules/json.js
+++ b/src/rules/json.js
@@ -1,0 +1,49 @@
+import { isNullOrUndefined } from '../utils';
+
+const isObject = obj => {
+  const type = typeof obj;
+  return type === 'function' || (type === 'object' && !!obj);
+};
+
+const validate = (value, { type } = {}) => {
+  if (isNullOrUndefined(value)) {
+    value = '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(val => validate(val, [type]));
+  }
+
+  try {
+    const jsonValue = JSON.parse(value);
+
+    if (type === 'array_object') {
+      if (Array.isArray(jsonValue)) {
+        jsonValue.forEach(value => {
+          if (!isObject(value)) throw new Error('is not Object');
+        });
+
+        return true;
+      }
+
+      return false;
+    } else if (type === 'array') {
+      return Array.isArray(jsonValue);
+    } else if (type === 'object') {
+      return isObject(jsonValue) && !Array.isArray(jsonValue);
+    }
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+};
+
+const paramNames = ['type'];
+
+export { validate, paramNames };
+
+export default {
+  validate,
+  paramNames
+};

--- a/tests/unit/rules/json.js
+++ b/tests/unit/rules/json.js
@@ -1,0 +1,61 @@
+import { validate } from '@/rules/json';
+
+const valid = [
+  '[1,"value",{"key":"value"}]',
+  '{"key":"value"}',
+  '[{"key":"value"},{"key":"value"}]',
+  [
+    '[1,"value",{"key":"value"}]',
+    '{"key":"value"}',
+    '[{"key":"value"},{"key":"value"}]'
+  ]
+];
+
+const invalid = [
+  '[1,value,{key:value}]',
+  '{key:value}',
+  '[{key:value},key:value}]',
+  [
+    '[1,value",{key":"value"}]',
+    '{"key":"value"}',
+    '[{"key":value},{"key":"value"}]'
+  ],
+  undefined,
+  null
+];
+
+test('validates that the string is a valid json', () => {
+  expect.assertions(10);
+  // valid.
+  valid.forEach(value => expect(validate(value)).toBe(true));
+
+  // invalid
+  invalid.forEach(value => expect(validate(value)).toBe(false));
+});
+
+test('validates json (array)', () => {
+  const valid = '[1,"value",{"key":"value"}]';
+  expect(validate(valid, { type: 'array' })).toBe(true);
+
+  const invalid = '{"key":"value"}';
+  expect(validate(invalid, { type: 'array' })).toBe(false);
+});
+
+test('validates json (array_object)', () => {
+  const valid = '[{"key":"value"},{"key":"value"}]';
+  expect(validate(valid, { type: 'array_object' })).toBe(true);
+
+  const invalid = '[1,"value",{"key":"value"}]';
+  expect(validate(invalid, { type: 'array_object' })).toBe(false);
+
+  const invalid2 = '{"key":"value"}';
+  expect(validate(invalid2, { type: 'array_object' })).toBe(false);
+});
+
+test('validates json (object)', () => {
+  const valid = '{"key":"value"}';
+  expect(validate(valid, { type: 'object' })).toBe(true);
+
+  const invalid = '[1,"value",{"key":"value"}]';
+  expect(validate(invalid, { type: 'object' })).toBe(false);
+});


### PR DESCRIPTION
Hello,
This PR add `json` rule for allow check is the string value is an valid json (array, array of object, object or any json)


### /!\  Question :
How i can fix the localization message (the switch is not work because argument is `{1}`
Note: i have also try with :
```js
return `The ${field} field must be an valid json ${type === 'array_object' ? 'array of object' : type}.`;
```

Thanks.