### PR TITLE
fix(types): allow return object on RuleValidate

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -68,8 +68,13 @@ export interface IDictionary {
     setDateFormat(locale: string, format: string): void;
 }
 
+export type ResultObject = {
+    valid: boolean;
+    data?: object;
+}
+
 export interface RuleValidate {
-    (value: any, args: object | any[], data?: any): boolean | Promise<boolean>
+    (value: any, args: object | any[], data?: any): boolean | ResultObject | Promise<boolean | ResultObject>
 }
 
 export interface Rule {


### PR DESCRIPTION
Hello,
This PR fix the types definition for allow return object in `validate`. This is applicable for example for rules `dimensions` and `required_if`.

Thanks.