### PR TITLE
fix: merge dictionary on locale change

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -128,6 +128,10 @@ class VeeValidate {
   _initI18n (config) {
     const { dictionary, i18n, i18nRootKey, locale } = config;
     const onLocaleChanged = () => {
+      if (dictionary) {
+        this.i18nDriver.merge(dictionary);
+      }
+
       this._validator.errors.regenerate();
     };
 


### PR DESCRIPTION
🔎 __Overview__

This fix addresses an issue occurring at i18n locale change when you use locale lazy loading.

Because, since the initial merge doesn't have the switched language in memory, it needs to be merged again when the locale change event is received.