### PR TITLE
fix: add exponential notation to decimal rule

### DIFF
--- a/src/rules/decimal.js
+++ b/src/rules/decimal.js
@@ -15,7 +15,7 @@ const validate = (value, { decimals = '*', separator = '.' } = {}) => {
   }
 
   const regexPart = decimals === '*' ? '+' : `{1,${decimals}}`;
-  const regex = new RegExp(`^[-+]?\\d*(\\${separator}\\d${regexPart})?$`);
+  const regex = new RegExp(`^[-+]?\\d*(\\${separator}\\d${regexPart})?([eE]{1}[-]?\\d+)?$`);
 
   if (! regex.test(value)) {
     return false;

--- a/tests/unit/rules/decimal.js
+++ b/tests/unit/rules/decimal.js
@@ -16,6 +16,10 @@ test('validates numerics with decmial numbers', () => {
   expect(validate('1', { decimails: 0 })).toBe(true);
   expect(validate('+1')).toBe(true);
   expect(validate('+1.2')).toBe(true);
+  expect(validate('1.2E-12')).toBe(true);
+  expect(validate('1.2e16')).toBe(true);
+  expect(validate('1.2E16')).toBe(true);
+  expect(validate('1.2e-12')).toBe(true);
 
   expect(validate('')).toBe(false);
   expect(validate(null)).toBe(false);


### PR DESCRIPTION
🔎 __Overview__

This PR  adds/fixes the scientific/exponential notation in the decimal validator for very large and small numbers. e.g. 1.3e-13, 4e15, 6.5e12, etc.
