### PR TITLE
fix: skip disabled fields only when useConstraintAttrs is enabled

### DIFF
--- a/src/core/validator.js
+++ b/src/core/validator.js
@@ -3,6 +3,7 @@ import FieldBag from './fieldBag';
 import Dictionary from '../dictionary';
 import RuleContainer from './ruleContainer';
 import Field from './field';
+import { getConfig } from '../config';
 import {
   isObject,
   getPath,
@@ -742,8 +743,8 @@ export default class Validator {
       return false;
     }
 
-    // disabled fields are skipped
-    if (field.isDisabled) {
+    // disabled fields are skipped if useConstraintAttrs is enabled in config
+    if (field.isDisabled && getConfig().useConstraintAttrs) {
       return true;
     }
 


### PR DESCRIPTION
🔎 __Overview__

The purpose of `useConstraintAttrs` is to consider attrs values, in my opinion it should also include the `disabled` attr in the shouldSkip function.
