### PR TITLE
fix(types): allow return array of result

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -73,8 +73,10 @@ export type ResultObject = {
     data?: object;
 }
 
+export type RuleResult = boolean | ResultObject | boolean[] | ResultObject[] | Promise<boolean | ResultObject | boolean[] | ResultObject[]>
+
 export interface RuleValidate {
-    (value: any, args: object | any[], data?: any): boolean | ResultObject | Promise<boolean | ResultObject>
+    (value: any, args: object | any[], data?: any): RuleResult
 }
 
 export interface Rule {


### PR DESCRIPTION
🔎 __Overview__

This PR fix the result of RuleValidate for allow return multiple results (like results in [dimensions rule](https://github.com/baianat/vee-validate/blob/master/src/rules/dimensions.js#L23))

🤓 __Code snippets/examples (if applicable)__

```ts
Validator.extend('max_dimensions', {
    getMessage: (field, [width, height]): string =>
      `The ${field} field must be UP TO ${width} pixels by ${height} pixels.`,
    validate (files, args) {
      const [width, height] = args as string[]
      const images = ensureArray(files).filter((file): boolean => imageRegex.test(file.name))
      if (images.length === 0) {
        return false
      }

      return Promise.all(images.map((file): Promise<ResultObject> => validateImage(file, width, height, true)))
    }
  })
```