### PR TITLE
fix(types): allow empty args

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -76,7 +76,7 @@ export type ResultObject = {
 export type RuleResult = boolean | ResultObject | boolean[] | ResultObject[] | Promise<boolean | ResultObject | boolean[] | ResultObject[]>
 
 export interface RuleValidate {
-    (value: any, args: object | any[], data?: any): RuleResult
+    (value: any, args?: object | any[], data?: any): RuleResult
 }
 
 export interface Rule {


### PR DESCRIPTION
🔎 __Overview__

This PR fixes the bug.

When we create custom rule without arguments we can call without pass args.

🤓 __Code snippets/examples (if applicable)__

```ts
const validate: RuleValidate = (value): boolean => {
  if (isNullOrUndefined(value)) {
    value = ''
  }

  if (Array.isArray(value)) {
    return value.every((val): boolean => validate(val) as boolean)
  }

  return semverRegex.test(value)
}

```