### PR TITLE
Fix wrong typo in the translation

### DIFF
--- a/locale/en.js
+++ b/locale/en.js
@@ -14,7 +14,7 @@ const messages = {
   date_between: (field, [min, max]) => `The ${field} must be between ${min} and ${max}.`,
   date_format: (field, [format]) => `The ${field} must be in the format ${format}.`,
   decimal: (field, [decimals = '*'] = []) => `The ${field} field must be numeric and may contain ${!decimals || decimals === '*' ? '' : decimals} decimal points.`,
-  digits: (field, [length]) => `The ${field} field must be numeric and exactly contain ${length} digits.`,
+  digits: (field, [length]) => `The ${field} field must be numeric and contains exactly ${length} digits.`,
   dimensions: (field, [width, height]) => `The ${field} field must be ${width} pixels by ${height} pixels.`,
   email: (field) => `The ${field} field must be a valid email.`,
   excluded: (field) => `The ${field} field must be a valid value.`,


### PR DESCRIPTION
🔎 __Overview__

This PR improves EN localization.
I think the translation of the `digits` is not good.

Ex (Locale):
> This PR changes the EN messages style because wrong typo
