### PR TITLE
fix(types): class names are not all mandatory

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -11,12 +11,12 @@ export interface VeeValidateComponentOptions {
 }
 
 export interface ClassNames {
-    touched: string;
-    untouched: string;
-    valid: string;
-    invalid: string;
-    pristine: string;
-    dirty: string;
+    touched?: string;
+    untouched?: string;
+    valid?: string;
+    invalid?: string;
+    pristine?: string;
+    dirty?: string;
 }
 
 export interface Configuration {


### PR DESCRIPTION
🔎 __Overview__
This PR updates the type of `ClassNames` to make every field optional.


🤓 __Code snippets/examples (if applicable)__

AFAIK, it is possible to only declare:

```typescript
Vue.use(VeeValidate, {
  classes: true,
  classNames: {
    invalid: 'is-invalid',
  },
});
```
without having to declare every classes.
The current typings don't allow that.
The PR makes every class optional, making such a configuration possible.
