### PR TITLE
fix: vue types unuse parameter

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -3,7 +3,7 @@
  */
 
 import Vue, { ComponentOptions } from 'vue';
-import { ErrorBag, FieldFlagsBag, Validator, VeeValidateComponentOptions } from './vee-validate.d';
+import { Validator, VeeValidateComponentOptions } from './vee-validate.d';
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {


### PR DESCRIPTION
🔎 __Overview__

remove unuse parameter

`ErrorBag` and `FieldFlagsBag ` are removed https://github.com/baianat/vee-validate/commit/fedea704e01aaa64749c04c891b74c1be6d70c12