### PR TITLE
fix(types): add missing options on extend

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -478,8 +478,10 @@ export class Validator {
 export class ExtendOptions {
     hasTarget?: boolean;
     paramNames?: string[];
-    computesRequired?: Boolean
-    initial?: Boolean
+    computesRequired?: boolean;
+    initial?: boolean;
+    immediate?: boolean;
+    isDate?: boolean;
 }
 
 /**


### PR DESCRIPTION
Hello,

This PR fix an missing options on extend (immediate and isDate) and fix wrong type/syntax for `computesRequired` and `initial`.

Thanks.