### PR TITLE
Create a empty messages object when not exists

### DIFF
--- a/src/localization/default.js
+++ b/src/localization/default.js
@@ -111,6 +111,10 @@ export default class Dictionary implements IDictionary {
         attributes: {}
       };
     }
+    
+    if (!this.container[locale].messages) {
+      this.container[locale].messages = {}
+    }
 
     this.container[locale].messages[key] = message;
   }

--- a/tests/unit/localization/default.js
+++ b/tests/unit/localization/default.js
@@ -70,6 +70,17 @@ test('can set messages', () => {
   expect(dict.getMessage('en', 'winter')).toBe('Winter is coming');
 });
 
+test('can set messages when no messages present', () => {
+  const dict = new Dictionary();
+  dict.merge({
+    'nl': {}
+  });
+
+  dict.setMessage('nl', 'winter', 'De winter komt er aan');
+
+  expect(dict.getMessage('nl', 'winter')).toBe('De winter komt er aan');
+});
+
 test('can set attributes', () => {
   const dict = new Dictionary({
     en: {


### PR DESCRIPTION
Fix:
If you set a custom message with setMessage and no message object exists you get an error