### PR TITLE
Fix minor spelling errors in syntax.md

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -23,9 +23,9 @@ const multiple = {
 
 ## Rules Parameters
 
-Some rules can have parameters, which can be specified in multiple ways for convience:
+Some rules can have parameters, which can be specified in multiple ways for convenience:
 
-- As a comma seperated list which is suitable for the string format.
+- As a comma separated list which is suitable for the string format.
 - An array containing the params values (Suitable for the object format).
 - An object (Provides more complex configuration for the rules in object format), but with a [caveat](/guide/custom-rules.md#args-and-rule-configuration).
 


### PR DESCRIPTION
Fixes some spelling errors in the syntax doc. Specifically on lines 26 and 28.