### PR TITLE
Typo in 3.x docs warning: "this is a the docs"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ meta:
 
 :::danger Version
 
-This is a the docs for vee-validate 3.x. You access the docs for the old version 2.x [from here](http://vee-validate.logaretm.com/v2).
+This is the docs for vee-validate 3.x. You access the docs for the old version 2.x [from here](http://vee-validate.logaretm.com/v2).
 
 :::
 


### PR DESCRIPTION
Simple grammar fix when opening the initial docs page.

🔎 __Overview__

Important because there's a typo right on the docs homepage! :)

Ex (fix):
> This PR improves the homepage documentation 3.x warning.
