### PR TITLE
Missing an "async" declaration

### DIFF
--- a/docs/guide/validation-observer.md
+++ b/docs/guide/validation-observer.md
@@ -101,7 +101,7 @@ Validating before submit is very easy way, using the [public methods](#methods) 
 <script>
 export default {
   methods: {
-    submit () {
+    async submit () {
       const isValid = await this.$refs.observer.validate();
       if (!isValid) {
         // ABORT!!


### PR DESCRIPTION
🔎 __Overview__

One of the examples has an "await" operator inside a function missing the "async" declaration.