### PR TITLE
Correction in the translation of "confirmed" rule for pt_BR and pt_PT

### DIFF
--- a/locale/pt_BR.json
+++ b/locale/pt_BR.json
@@ -6,7 +6,7 @@
     "alpha_num": "O campo {_field_} deve conter somente letras e números",
     "alpha_spaces": "O campo {_field_} só pode conter caracteres alfabéticos e espaços",
     "between": "O campo {_field_} deve estar entre {min} e {max}",
-    "confirmed": "Os campos {_field_} e {target} devem ser iguais",
+    "confirmed": "A confirmação do campo {_field_} deve ser igual",
     "digits": "O campo {_field_} deve ser numérico e ter exatamente {length} dígitos",
     "dimensions": "O campo {_field_} deve ter {width} pixels de largura por {height} pixels de altura",
     "email": "O campo {_field_} deve ser um email válido",

--- a/locale/pt_PT.json
+++ b/locale/pt_PT.json
@@ -6,7 +6,7 @@
     "alpha_num": "O campo {_field_} deve conter somente letras e números",
     "alpha_spaces": "O {_field_} só pode conter caracteres alfabéticos e espaços",
     "between": "O campo {_field_} deve estar entre {min} e {max}",
-    "confirmed": "Os campos {_field_} e {target} devem ser iguais",
+    "confirmed": "A confirmação do campo {_field_} deve ser igual",
     "digits": "O campo {_field_} deve ser numérico e ter {length} dígitos",
     "dimensions": "O campo {_field_} deve ter {width} pixels de largura por {height} pixels de altura",
     "email": "O campo {_field_} deve ser um email válido",


### PR DESCRIPTION
The `{target}` doesn't make sense anymore in the messages. Just for record, the same occur in the following languages.

- ca
- da
- el
- fi
- fr (also in the `required_if` rule)
- id
- it
- ka
- pl
- ru
- sv
- vi
- zh_CN
- zh_TW