### PR TITLE
Fix example from using v2 syntax

### DIFF
--- a/docs/guide/validation-provider.md
+++ b/docs/guide/validation-provider.md
@@ -108,11 +108,11 @@ You can use these flags to give your users a great experience, for example you c
 ```vue
 <ValidationProvider
   rules="required"
-  v-slot="{ flags }"
+  v-slot="{ changed }"
 >
   <input type="text" v-model="value">
 
-  <button :disabled="!flags.changed">Submit</button>
+  <button :disabled="!changed">Submit</button>
 </ValidationProvider>
 ```
 


### PR DESCRIPTION
🔎 __Overview__

I was reading documentation of new version, and found usage of old syntax. As I know, in v3 there is no `flags` property available, instead flags are directly available.
